### PR TITLE
MODDICONV-304: Require permissions interface 5.6 for module rename

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -2,7 +2,12 @@
   "id": "${artifactId}-${version}",
   "replaces" : [ "mod-data-import-converter-storage" ],
   "name": "Data Import Converter Storage",
-  "requires": [],
+  "requires" : [
+    {
+      "id" : "permissions",
+      "version" : "5.6"
+    }
+  ],
   "provides": [
     {
       "id": "data-import-converter-storage",


### PR DESCRIPTION
https://issues.folio.org/browse/MODDICONV-304

Upgrading to Nolana to Orchid-GA fails when the upgrade from mod-data-import-converter-storage to mod-di-converter-storage (rename!) is executed before the upgrade of mod-permissions.

Reason: The module rename requires the Orchid version of mod-permissions.

Fix: Add a dependency to ModuleDescriptor to enforce the upgrade order:

* Add a permissions 5.6 dependency to mod-di-converter-storage.