### PR TITLE
MODDICONV-300: Match and action profiles cannot be re-used in an import job profile - short term fix

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 2023-XX-XX 2.1.0-SNAPSHOT
+* [MODDICONV-300](https://issues.folio.org/browse/MODDICONV-300) Match and action profiles cannot be re-used in an import job profile - short term fix
+
 ## 2022-02-14 v2.0.0
 * [MODDICONV-259](https://issues.folio.org/browse/MODDICONV-259) Rename mod-data-import-converter-storage module to mod-di-converter-storage
 * [MODDICONV-271](https://issues.folio.org/browse/MODDICONV-271) Logging improvement - Configuration

--- a/mod-di-converter-storage-server/src/main/java/org/folio/services/AbstractProfileService.java
+++ b/mod-di-converter-storage-server/src/main/java/org/folio/services/AbstractProfileService.java
@@ -175,17 +175,17 @@ public abstract class AbstractProfileService<T, S, D> implements ProfileService<
   @Override
   public Future<Boolean> isProfileDtoValidForUpdate(String id, D profile, boolean isDefaultProfile, String tenantId) {
     return isDefaultProfile ? getProfileById(id, false, tenantId).map(profileOptional ->
-        profileOptional.map(fetchedProfile -> Stream.of(getProfile(profile), fetchedProfile).map(JsonObject::mapFrom)
-          .peek(jsonObject -> {
-            jsonObject.remove("tags");
-            jsonObject.remove("metadata");
-          }).distinct().count() <= 1).orElse(false)) : Future.succeededFuture(true);
+      profileOptional.map(fetchedProfile -> Stream.of(getProfile(profile), fetchedProfile).map(JsonObject::mapFrom)
+        .peek(jsonObject -> {
+          jsonObject.remove("tags");
+          jsonObject.remove("metadata");
+        }).distinct().count() <= 1).orElse(false)) : Future.succeededFuture(true);
   }
 
   @Override
   public Future<Boolean> isProfileContainsChildProfiles(T profile) {
     List<ProfileSnapshotWrapper> childProfiles = getChildProfiles(profile);
-    return Future.succeededFuture(childProfiles!= null && !childProfiles.isEmpty());
+    return Future.succeededFuture(childProfiles != null && !childProfiles.isEmpty());
   }
 
   @Override
@@ -384,18 +384,14 @@ public abstract class AbstractProfileService<T, S, D> implements ProfileService<
     return promise.future();
   }
 
-  private static <T> Predicate<T> distinctByKeys(final Function<? super T, ?>... keyExtractors)
-  {
+  private static <T> Predicate<T> distinctByKeys(final Function<? super T, ?>... keyExtractors) {
     final Map<List<?>, Boolean> seen = new ConcurrentHashMap<>();
-
-    return t ->
+    return e ->
     {
       final List<?> keys = Arrays.stream(keyExtractors)
-        .map(ke -> ke.apply(t))
+        .map(ke -> ke.apply(e))
         .collect(Collectors.toList());
-
       return seen.putIfAbsent(keys, Boolean.TRUE) == null;
     };
   }
-
 }

--- a/mod-di-converter-storage-server/src/main/java/org/folio/services/AbstractProfileService.java
+++ b/mod-di-converter-storage-server/src/main/java/org/folio/services/AbstractProfileService.java
@@ -23,11 +23,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -384,8 +383,8 @@ public abstract class AbstractProfileService<T, S, D> implements ProfileService<
     return promise.future();
   }
 
-  private static <T> Predicate<T> distinctByKeys(final Function<? super T, ?>... keyExtractors) {
-    final Map<List<?>, Boolean> seen = new ConcurrentHashMap<>();
+  private <B> Predicate<B> distinctByKeys(final Function<? super B, ?>... keyExtractors) {
+    final Map<List<?>, Boolean> seen = new HashMap<>();
     return e ->
     {
       final List<?> keys = Arrays.stream(keyExtractors)

--- a/mod-di-converter-storage-server/src/test/java/org/folio/rest/impl/association/CommonProfileAssociationTest.java
+++ b/mod-di-converter-storage-server/src/test/java/org/folio/rest/impl/association/CommonProfileAssociationTest.java
@@ -1120,7 +1120,7 @@ public class CommonProfileAssociationTest extends AbstractRestVerticleTest {
   }
 
   @Test
-  public void testShouldSaveOnlyUniqueAssociation(TestContext testContext) {
+  public void shouldSaveOnlyUniqueAssociations(TestContext testContext) {
     Async async = testContext.async();
 
     String mainMatchProfileId = "cfb7ad96-6bbb-4843-9e3a-0395190bd6c8";

--- a/mod-di-converter-storage-server/src/test/java/org/folio/rest/impl/association/CommonProfileAssociationTest.java
+++ b/mod-di-converter-storage-server/src/test/java/org/folio/rest/impl/association/CommonProfileAssociationTest.java
@@ -1,5 +1,6 @@
 package org.folio.rest.impl.association;
 
+import com.google.common.collect.Lists;
 import io.restassured.RestAssured;
 import io.restassured.response.Response;
 import io.vertx.core.Future;
@@ -77,49 +78,49 @@ public class CommonProfileAssociationTest extends AbstractRestVerticleTest {
 
   ActionProfileUpdateDto actionProfile1 = new ActionProfileUpdateDto()
     .withProfile(new ActionProfile().withName("testActionProfile1").withDescription("test-description")
-    .withAction(CREATE).withFolioRecord(MARC_BIBLIOGRAPHIC));
+      .withAction(CREATE).withFolioRecord(MARC_BIBLIOGRAPHIC));
   ActionProfileUpdateDto actionProfile2 = new ActionProfileUpdateDto()
     .withProfile(new ActionProfile().withName("testActionProfile2").withDescription("test-description")
-    .withAction(CREATE).withFolioRecord(MARC_BIBLIOGRAPHIC));
+      .withAction(CREATE).withFolioRecord(MARC_BIBLIOGRAPHIC));
   ActionProfileUpdateDto actionProfile3 = new ActionProfileUpdateDto()
     .withProfile(new ActionProfile().withName("testActionProfile3").withDescription("test-description")
-    .withAction(CREATE).withFolioRecord(MARC_BIBLIOGRAPHIC));
+      .withAction(CREATE).withFolioRecord(MARC_BIBLIOGRAPHIC));
   ActionProfileUpdateDto actionProfile4 = new ActionProfileUpdateDto()
     .withProfile(new ActionProfile().withName("testActionProfile4")
-    .withAction(CREATE).withFolioRecord(MARC_BIBLIOGRAPHIC));
+      .withAction(CREATE).withFolioRecord(MARC_BIBLIOGRAPHIC));
 
   MappingProfileUpdateDto mappingProfile1 = new MappingProfileUpdateDto()
     .withProfile(new MappingProfile().withName("testMappingProfile1").withDescription("test-description")
-    .withIncomingRecordType(EntityType.MARC_BIBLIOGRAPHIC)
-    .withExistingRecordType(EntityType.INSTANCE));
+      .withIncomingRecordType(EntityType.MARC_BIBLIOGRAPHIC)
+      .withExistingRecordType(EntityType.INSTANCE));
   MappingProfileUpdateDto mappingProfile2 = new MappingProfileUpdateDto()
     .withProfile(new MappingProfile().withName("testMappingProfile2").withDescription("test-description")
-    .withIncomingRecordType(EntityType.MARC_BIBLIOGRAPHIC)
-    .withExistingRecordType(EntityType.INSTANCE));
+      .withIncomingRecordType(EntityType.MARC_BIBLIOGRAPHIC)
+      .withExistingRecordType(EntityType.INSTANCE));
   MappingProfileUpdateDto mappingProfile3 = new MappingProfileUpdateDto()
     .withProfile(new MappingProfile().withName("testMappingProfile3")
-    .withIncomingRecordType(EntityType.MARC_BIBLIOGRAPHIC)
-    .withExistingRecordType(EntityType.INSTANCE));
+      .withIncomingRecordType(EntityType.MARC_BIBLIOGRAPHIC)
+      .withExistingRecordType(EntityType.INSTANCE));
 
   MatchProfileUpdateDto matchProfile1 = new MatchProfileUpdateDto()
     .withProfile(new MatchProfile().withName("testMatchProfile1")
-    .withIncomingRecordType(EntityType.MARC_BIBLIOGRAPHIC)
-    .withExistingRecordType(EntityType.MARC_BIBLIOGRAPHIC)
-    .withDescription("test-description"));
+      .withIncomingRecordType(EntityType.MARC_BIBLIOGRAPHIC)
+      .withExistingRecordType(EntityType.MARC_BIBLIOGRAPHIC)
+      .withDescription("test-description"));
   MatchProfileUpdateDto matchProfile2 = new MatchProfileUpdateDto()
     .withProfile(new MatchProfile().withName("testMatchProfile2")
-    .withIncomingRecordType(EntityType.MARC_BIBLIOGRAPHIC)
-    .withExistingRecordType(EntityType.MARC_BIBLIOGRAPHIC)
-    .withDescription("test-description"));
+      .withIncomingRecordType(EntityType.MARC_BIBLIOGRAPHIC)
+      .withExistingRecordType(EntityType.MARC_BIBLIOGRAPHIC)
+      .withDescription("test-description"));
   MatchProfileUpdateDto matchProfile3 = new MatchProfileUpdateDto()
     .withProfile(new MatchProfile().withName("testMatchProfile3")
-    .withIncomingRecordType(EntityType.MARC_BIBLIOGRAPHIC)
-    .withExistingRecordType(EntityType.MARC_BIBLIOGRAPHIC)
-    .withDescription("test-description"));
+      .withIncomingRecordType(EntityType.MARC_BIBLIOGRAPHIC)
+      .withExistingRecordType(EntityType.MARC_BIBLIOGRAPHIC)
+      .withDescription("test-description"));
   MatchProfileUpdateDto matchProfile4 = new MatchProfileUpdateDto()
     .withProfile(new MatchProfile().withName("testMatchProfile4")
-    .withIncomingRecordType(EntityType.MARC_BIBLIOGRAPHIC)
-    .withExistingRecordType(EntityType.MARC_BIBLIOGRAPHIC));
+      .withIncomingRecordType(EntityType.MARC_BIBLIOGRAPHIC)
+      .withExistingRecordType(EntityType.MARC_BIBLIOGRAPHIC));
 
   @Test
   public void runTestShouldReturnEmptyOkResultOnGetAll(TestContext testContext) {
@@ -1114,6 +1115,186 @@ public class CommonProfileAssociationTest extends AbstractRestVerticleTest {
       .body("childSnapshotWrappers.size()", is(2))
       .body("childSnapshotWrappers[0].content.name", is(masterWrapper1.getName()))
       .body("childSnapshotWrappers[1].content.name", is(masterWrapper2.getName()));
+
+    clearTables(testContext);
+  }
+
+  @Test
+  public void testShouldSaveOnlyUniqueAssociation(TestContext testContext) {
+    Async async = testContext.async();
+
+    String mainMatchProfileId = "cfb7ad96-6bbb-4843-9e3a-0395190bd6c8";
+    String firstSubMatchProfileId = "fe7c81d1-6da5-4210-89dd-3c06208e2821";
+    String secondSubMatchProfileId = "8baf9046-068a-42a6-8b0f-150c8c934c1f";
+    String thirdSubMatchProfileId = "f14271b1-2f64-430c-b4f9-0e2ab30e1180";
+    String firstActionProfileId = "fa45f3ec-9b83-11eb-a8b3-0242ac130003";
+    String secondActionProfileId = "8aa0b850-9182-4005-8435-340b704b2a19";
+
+    String jobProfileId = UUID.randomUUID().toString();
+
+    MatchProfileUpdateDto mainMatchProfile = new MatchProfileUpdateDto()
+      .withProfile(new MatchProfile().withName("Main Test Match Profile")
+        .withIncomingRecordType(EntityType.MARC_BIBLIOGRAPHIC)
+        .withExistingRecordType(EntityType.MARC_BIBLIOGRAPHIC)
+        .withDescription("test-description")
+        .withId(mainMatchProfileId));
+
+    MatchProfileUpdateDto firstSubMatchProfile = new MatchProfileUpdateDto()
+      .withProfile(new MatchProfile().withName("First Sub Match Profile")
+        .withIncomingRecordType(EntityType.MARC_BIBLIOGRAPHIC)
+        .withExistingRecordType(EntityType.MARC_BIBLIOGRAPHIC)
+        .withDescription("test-description")
+        .withId(firstSubMatchProfileId));
+
+    MatchProfileUpdateDto secondSubMatchProfile = new MatchProfileUpdateDto()
+      .withProfile(new MatchProfile().withName("Second Sub Match Profile")
+        .withIncomingRecordType(EntityType.MARC_BIBLIOGRAPHIC)
+        .withExistingRecordType(EntityType.MARC_BIBLIOGRAPHIC)
+        .withDescription("test-description")
+        .withId(secondSubMatchProfileId));
+
+    MatchProfileUpdateDto thirdSubMatchProfile = new MatchProfileUpdateDto()
+      .withProfile(new MatchProfile().withName("Third Sub Match Profile")
+        .withIncomingRecordType(EntityType.MARC_BIBLIOGRAPHIC)
+        .withExistingRecordType(EntityType.MARC_BIBLIOGRAPHIC)
+        .withDescription("test-description")
+        .withId(thirdSubMatchProfileId));
+
+    ActionProfileUpdateDto firstActionProfile = new ActionProfileUpdateDto()
+      .withProfile(new ActionProfile()
+        .withAction(ActionProfile.Action.UPDATE)
+        .withName("First Testing Action Profile")
+        .withDeleted(false)
+        .withFolioRecord(MARC_BIBLIOGRAPHIC)
+        .withId(firstActionProfileId));
+
+    ActionProfileUpdateDto secondActionProfile = new ActionProfileUpdateDto()
+      .withProfile(new ActionProfile()
+        .withAction(ActionProfile.Action.UPDATE)
+        .withName("Second Testing Action Profile")
+        .withDeleted(false)
+        .withFolioRecord(MARC_BIBLIOGRAPHIC)
+        .withId(secondActionProfileId));
+
+    postProfile(testContext, new MatchProfileWrapper(mainMatchProfile), MATCH_PROFILES_URL);
+    postProfile(testContext, new MatchProfileWrapper(firstSubMatchProfile), MATCH_PROFILES_URL);
+    postProfile(testContext, new MatchProfileWrapper(secondSubMatchProfile), MATCH_PROFILES_URL);
+    postProfile(testContext, new MatchProfileWrapper(thirdSubMatchProfile), MATCH_PROFILES_URL);
+
+    postProfile(testContext, new ActionProfileWrapper(firstActionProfile), ACTION_PROFILES_URL);
+    postProfile(testContext, new ActionProfileWrapper(secondActionProfile), ACTION_PROFILES_URL);
+
+    JobProfileWrapper mainJobProfileWrapper = new JobProfileWrapper(new JobProfileUpdateDto()
+      .withProfile(new JobProfile()
+        .withId(jobProfileId)
+        .withName("Testing JobProfile")
+        .withDataType(MARC)
+        .withDeleted(false)
+        .withHidden(false)
+        .withDescription("test-description"))
+      .withAddedRelations(Lists.newArrayList(
+        //0
+        new ProfileAssociation()
+          .withDetailProfileId(mainMatchProfileId)
+          .withMasterProfileType(ProfileAssociation.MasterProfileType.JOB_PROFILE)
+          .withDetailProfileType(ProfileAssociation.DetailProfileType.MATCH_PROFILE)
+          .withTriggered(false),
+        //1
+        new ProfileAssociation()
+          .withMasterProfileId(mainMatchProfileId)
+          .withDetailProfileId(firstSubMatchProfileId)
+          .withDetailProfileType(ProfileAssociation.DetailProfileType.MATCH_PROFILE)
+          .withMasterProfileType(ProfileAssociation.MasterProfileType.MATCH_PROFILE)
+          .withTriggered(false)
+          .withReactTo(ProfileAssociation.ReactTo.MATCH),
+        //2
+        new ProfileAssociation()
+          .withMasterProfileId(secondSubMatchProfileId)
+          .withDetailProfileId(firstSubMatchProfileId)
+          .withMasterProfileType(ProfileAssociation.MasterProfileType.MATCH_PROFILE)
+          .withDetailProfileType(ProfileAssociation.DetailProfileType.MATCH_PROFILE)
+          .withTriggered(false)
+          .withReactTo(ProfileAssociation.ReactTo.MATCH),
+        //3
+        new ProfileAssociation()
+          .withMasterProfileId(secondSubMatchProfileId)
+          .withDetailProfileId(firstActionProfileId)
+          .withMasterProfileType(ProfileAssociation.MasterProfileType.MATCH_PROFILE)
+          .withDetailProfileType(ProfileAssociation.DetailProfileType.ACTION_PROFILE)
+          .withTriggered(false)
+          .withReactTo(ProfileAssociation.ReactTo.MATCH),
+        //4
+        new ProfileAssociation()
+          .withMasterProfileId(secondSubMatchProfileId)
+          .withDetailProfileId(secondActionProfileId)
+          .withMasterProfileType(ProfileAssociation.MasterProfileType.MATCH_PROFILE)
+          .withDetailProfileType(ProfileAssociation.DetailProfileType.ACTION_PROFILE)
+          .withTriggered(false)
+          .withReactTo(ProfileAssociation.ReactTo.MATCH),
+        //5
+        new ProfileAssociation()
+          .withMasterProfileId(mainMatchProfileId)
+          .withDetailProfileId(thirdSubMatchProfileId)
+          .withMasterProfileType(ProfileAssociation.MasterProfileType.MATCH_PROFILE)
+          .withDetailProfileType(ProfileAssociation.DetailProfileType.MATCH_PROFILE)
+          .withTriggered(false)
+          .withReactTo(ProfileAssociation.ReactTo.NON_MATCH),
+        //6
+        new ProfileAssociation()
+          .withMasterProfileId(thirdSubMatchProfileId)
+          .withDetailProfileId(firstSubMatchProfileId)
+          .withMasterProfileType(ProfileAssociation.MasterProfileType.MATCH_PROFILE)
+          .withDetailProfileType(ProfileAssociation.DetailProfileType.MATCH_PROFILE)
+          .withTriggered(false)
+          .withReactTo(ProfileAssociation.ReactTo.MATCH),
+        //7
+        new ProfileAssociation()
+          .withMasterProfileId(firstSubMatchProfileId)
+          .withDetailProfileId(secondSubMatchProfileId)
+          .withMasterProfileType(ProfileAssociation.MasterProfileType.MATCH_PROFILE)
+          .withDetailProfileType(ProfileAssociation.DetailProfileType.MATCH_PROFILE)
+          .withTriggered(false)
+          .withReactTo(ProfileAssociation.ReactTo.MATCH),
+        //8
+        new ProfileAssociation()
+          .withMasterProfileId(secondSubMatchProfileId)
+          .withDetailProfileId(firstActionProfileId)
+          .withMasterProfileType(ProfileAssociation.MasterProfileType.MATCH_PROFILE)
+          .withDetailProfileType(ProfileAssociation.DetailProfileType.ACTION_PROFILE)
+          .withTriggered(false)
+          .withReactTo(ProfileAssociation.ReactTo.MATCH),
+        //9
+        new ProfileAssociation()
+          .withMasterProfileId(secondSubMatchProfileId)
+          .withDetailProfileId(secondActionProfileId)
+          .withMasterProfileType(ProfileAssociation.MasterProfileType.MATCH_PROFILE)
+          .withDetailProfileType(ProfileAssociation.DetailProfileType.ACTION_PROFILE)
+          .withTriggered(false)
+          .withReactTo(ProfileAssociation.ReactTo.MATCH))));
+    RestAssured.given()
+      .spec(spec)
+      .body(mainJobProfileWrapper.getProfile())
+      .when()
+      .post(JOB_PROFILES_URL)
+      .then().log().all()
+      .statusCode(HttpStatus.SC_CREATED)
+      .body("profile.id", is(jobProfileId))
+      .body("addedRelations.size()", is(10))
+      .body("deletedRelations.size()", is(0));
+
+    async.complete();
+
+    async = testContext.async();
+    RestAssured.given()
+      .spec(spec)
+      .queryParam("master", MATCH_PROFILE)
+      .queryParam("detail", ACTION_PROFILE)
+      .when()
+      .get(ASSOCIATED_PROFILES_URL)
+      .then()
+      .statusCode(HttpStatus.SC_OK)
+      .body("totalRecords", is(2));
+    async.complete();
 
     clearTables(testContext);
   }


### PR DESCRIPTION
## Purpose
add constraint (or BE validation) when creating associations to ignore creation of duplicate association in scope of one job profile. It will allow creating profiles reusing the same building blocks (match and action profile structure). Such fix will be incomplete though - described case will be covered, but in case different building blocks would be required using same associations, we still might run into a problem.
## Approach
Added deduplication for the ProfileAssociation saving.


## Learning
(https://issues.folio.org/browse/MODDICONV-300)
