### PR TITLE
MODDICONV-307: Populate "value" with empty string if this field is absent in match profile incoming records indicators

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 * [MODDICONV-300](https://issues.folio.org/browse/MODDICONV-300) Match and action profiles cannot be re-used in an import job profile - short term fix
 * [MODDICONV-310](https://issues.folio.org/browse/MODDICONV-310) Add wrappers around profiles to build associations.
 * [MODDICONV-297](https://issues.folio.org/browse/MODDICONV-297) Add migration script for profiles with mapping for required subfields.
+* [MODDICONV-307](https://issues.folio.org/browse/MODDICONV-307) Populate "value" with empty string if this field is absent in match profile incoming records.
 
 ## 2022-02-14 v2.0.0
 * [MODDICONV-259](https://issues.folio.org/browse/MODDICONV-259) Rename mod-data-import-converter-storage module to mod-di-converter-storage

--- a/mod-di-converter-storage-server/src/main/resources/templates/db_scripts/data-migration/update_value_if_absent.sql
+++ b/mod-di-converter-storage-server/src/main/resources/templates/db_scripts/data-migration/update_value_if_absent.sql
@@ -1,0 +1,31 @@
+UPDATE ${myuniversity}_${mymodule}.match_profiles
+SET jsonb = jsonb_set(
+	jsonb,
+	'{matchDetails}',
+	(
+		SELECT jsonb_agg(
+			CASE
+					WHEN matchME->>'incomingMatchExpression' IS NOT NULL THEN
+					jsonb_set(matchME,'{incomingMatchExpression, fields}',
+					(
+					SELECT jsonb_agg(
+						CASE
+							WHEN fields_incoming->>'value' IS NULL THEN
+							jsonb_set(fields_incoming, '{value}','""')
+							ELSE
+							fields_incoming
+						END
+					)
+					FROM jsonb_array_elements(matchme->'incomingMatchExpression'->'fields') AS fields_incoming
+					)
+					)
+			ELSE matchME
+			END)
+		FROM jsonb_array_elements(jsonb-> 'matchDetails') AS matchME
+	)
+)
+WHERE EXISTS ( SELECT 1 FROM
+	jsonb_array_elements(jsonb->'matchDetails') AS matchDetails,
+jsonb_array_elements(matchDetails->'incomingMatchExpression'->'fields') AS fields_incoming
+WHERE fields_incoming->>'value' IS NULL
+);

--- a/mod-di-converter-storage-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-di-converter-storage-server/src/main/resources/templates/db_scripts/schema.json
@@ -382,6 +382,11 @@
       "run": "after",
       "snippetPath": "data-migration/populate_required_field_for_existing_profiles.sql",
       "fromModuleVersion": "mod-di-converter-storage-2.1.0"
+    },
+    {
+      "run": "after",
+      "snippetPath": "data-migration/update_value_if_absent.sql",
+      "fromModuleVersion": "mod-di-converter-storage-2.1.0"
     }
   ]
 }


### PR DESCRIPTION
## Purpose 
Populate "value" with empty string if this field is absent in match profile incoming records indicators.
## Approach
Keep in Poppy for now

Populate "value" with an empty string if this field is absent in match profile incoming records indicators.

As far as, if we would write a value to the indicator field at the matching profile and after that delete this value we will send the entity without the "value" field, we need to handle the absent value field on BE, to prevent producing of NPE.

Possibly in the field definition schema add default value for indicators to be empty string, not null. Update references to raml-storage.

Check if this problem is relevant for Action and Job profiles. For Mapping it should have been fixed already.

### P.S. 
After the investigation, not found any related issues on job and action profile. If you found any of these issues on the mentioned profile please comment it.