### PR TITLE
MODDICONV-346 fix unlinking for mapping-action associations

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 2023-XX-XX 2.1.3
+* [MODDICONV-346](https://issues.folio.org/browse/MODDICONV-346) Fix unlinking for action-mapping associations
+
 ## 2023-10-12 2.1.0
 * [MODDICONV-345](https://issues.folio.org/browse/MODDICONV-345) Set wrapper ids at jsonb for migrated relations
 * [MODDICONV-313](https://issues.folio.org/browse/MODDICONV-313) Upgrade mod-di-converter-storage to Java 17

--- a/mod-di-converter-storage-server/src/main/java/org/folio/dao/association/CommonProfileAssociationDao.java
+++ b/mod-di-converter-storage-server/src/main/java/org/folio/dao/association/CommonProfileAssociationDao.java
@@ -170,6 +170,8 @@ public class CommonProfileAssociationDao implements ProfileAssociationDao {
   public Future<Boolean> deleteByMasterIdAndDetailId(String masterId, String detailId, ContentType masterType, ContentType detailType, String tenantId) {
     Promise<RowSet<Row>> promise = Promise.promise();
     try {
+      /* Setting WHERE clause explicitly here because incorrect query is created by CQLWrapper by default due to
+      presence of 2 definitions of mapping tables in schema.json and the query is generated based on outdated definition */
       CQLWrapper filter = new CQLWrapper().setWhereClause(String.format(DELETE_BY_MASTER_ID_AND_DETAIL_ID_WHERE_CLAUSE,
         getAssociationTableName(masterType, detailType), masterId, detailId));
       pgClientFactory.createInstance(tenantId).delete(getAssociationTableName(masterType, detailType), filter, promise);

--- a/mod-di-converter-storage-server/src/main/java/org/folio/dao/association/CommonProfileAssociationDao.java
+++ b/mod-di-converter-storage-server/src/main/java/org/folio/dao/association/CommonProfileAssociationDao.java
@@ -42,8 +42,8 @@ public class CommonProfileAssociationDao implements ProfileAssociationDao {
   private static final String DETAIL_WRAPPER_ID_FIELD = "detailWrapperId";
   private static final String JOB_PROFILE_ID_FIELD = "jobProfileId";
   private static final String DELETE_BY_MASTER_ID_AND_DETAIL_ID_WHERE_CLAUSE =
-    "WHERE (left(lower(f_unaccent(%1$s.jsonb->>'masterProfileId')),600) LIKE lower(f_unaccent('%2$s'))) " +
-      "AND (lower(f_unaccent(%1$s.jsonb->>'detailProfileId')) LIKE lower(f_unaccent('%3$s')))";
+    "WHERE (left(lower(%1$s.jsonb->>'masterProfileId'),600) LIKE lower('%2$s')) " +
+      "AND (lower(%1$s.jsonb->>'detailProfileId') LIKE lower('%3$s'))";
   private static final Logger LOGGER = LogManager.getLogger();
   private static final String CORRECT_PROFILE_ASSOCIATION_TYPES_MESSAGE = "Correct ProfileAssociation types: " +
     "ACTION_PROFILE_TO_ACTION_PROFILE, " +

--- a/mod-di-converter-storage-server/src/main/java/org/folio/dao/association/ProfileAssociationDao.java
+++ b/mod-di-converter-storage-server/src/main/java/org/folio/dao/association/ProfileAssociationDao.java
@@ -69,8 +69,8 @@ public interface ProfileAssociationDao {
   /**
    * Delete ProfileAssociation  by masterWrapperId and detailWrapperId
    *
-   * @param masterWrapperId     - UUID of masterProfile
-   * @param detailWrapperId     - UUID of detailProfile
+   * @param masterWrapperId     - UUID of masterProfile wrapper
+   * @param detailWrapperId     - UUID of detailProfile wrapper
    * @param masterType   - master Profile Type
    * @param detailType   - detail Profile Type
    * @param tenantId     - tenant id
@@ -82,11 +82,23 @@ public interface ProfileAssociationDao {
   /**
    * Delete profile associations for particular master profile by wrapperId
    *
-   * @param wrapperId   - master profile id
+   * @param wrapperId   - master profile wrapper id
    * @param masterType - master profile type
    * @param detailType - detail profile type
    * @param tenantId   - tenant id
    * @return future with boolean
    */
-  Future<Boolean> deleteByMasterId(String wrapperId, ProfileSnapshotWrapper.ContentType masterType, ProfileSnapshotWrapper.ContentType detailType, String tenantId);
+  Future<Boolean> deleteByMasterWrapperId(String wrapperId, ProfileSnapshotWrapper.ContentType masterType, ProfileSnapshotWrapper.ContentType detailType, String tenantId);
+
+  /**
+   * Delete ProfileAssociation  by masterWrapperId and detailWrapperId
+   *
+   * @param masterId     - UUID of masterProfile
+   * @param detailId     - UUID of detailProfile
+   * @param masterType   - master Profile Type
+   * @param detailType   - detail Profile Type
+   * @param tenantId     - tenant id
+   * @return - boolean result of operation
+   */
+  Future<Boolean> deleteByMasterIdAndDetailId(String masterId, String detailId, ProfileSnapshotWrapper.ContentType masterType, ProfileSnapshotWrapper.ContentType detailType, String tenantId);
 }

--- a/mod-di-converter-storage-server/src/main/java/org/folio/services/ActionProfileServiceImpl.java
+++ b/mod-di-converter-storage-server/src/main/java/org/folio/services/ActionProfileServiceImpl.java
@@ -25,7 +25,7 @@ public class ActionProfileServiceImpl extends AbstractProfileService<ActionProfi
   @Override
   public Future<ActionProfile> updateProfile(ActionProfileUpdateDto profile, OkapiConnectionParams params) {
     setDefaults(profile.getProfile());
-    return super.updateProfile(profile, params, this::deleteRelatedAssociationsByMasterIdAndDetailId);
+    return super.updateProfile(profile, params);
   }
   @Override
   ActionProfile setProfileId(ActionProfile profile) {

--- a/mod-di-converter-storage-server/src/main/java/org/folio/services/ActionProfileServiceImpl.java
+++ b/mod-di-converter-storage-server/src/main/java/org/folio/services/ActionProfileServiceImpl.java
@@ -25,7 +25,7 @@ public class ActionProfileServiceImpl extends AbstractProfileService<ActionProfi
   @Override
   public Future<ActionProfile> updateProfile(ActionProfileUpdateDto profile, OkapiConnectionParams params) {
     setDefaults(profile.getProfile());
-    return super.updateProfile(profile, params);
+    return super.updateProfile(profile, params, this::deleteRelatedAssociationsByMasterIdAndDetailId);
   }
   @Override
   ActionProfile setProfileId(ActionProfile profile) {

--- a/mod-di-converter-storage-server/src/main/java/org/folio/services/MappingProfileServiceImpl.java
+++ b/mod-di-converter-storage-server/src/main/java/org/folio/services/MappingProfileServiceImpl.java
@@ -34,7 +34,7 @@ public class MappingProfileServiceImpl extends AbstractProfileService<MappingPro
   @Override
   public Future<MappingProfile> updateProfile(MappingProfileUpdateDto profileDto, OkapiConnectionParams params) {
     return deleteExistingActionToMappingAssociations(profileDto, params.getTenantId())
-      .compose(deleteAr -> super.updateProfile(profileDto, params, this::deleteRelatedAssociationsByMasterIdAndDetailId));
+      .compose(deleteAr -> super.updateProfile(profileDto, params));
   }
 
   @Override

--- a/mod-di-converter-storage-server/src/main/java/org/folio/services/MappingProfileServiceImpl.java
+++ b/mod-di-converter-storage-server/src/main/java/org/folio/services/MappingProfileServiceImpl.java
@@ -34,7 +34,7 @@ public class MappingProfileServiceImpl extends AbstractProfileService<MappingPro
   @Override
   public Future<MappingProfile> updateProfile(MappingProfileUpdateDto profileDto, OkapiConnectionParams params) {
     return deleteExistingActionToMappingAssociations(profileDto, params.getTenantId())
-      .compose(deleteAr -> super.updateProfile(profileDto, params));
+      .compose(deleteAr -> super.updateProfile(profileDto, params, this::deleteRelatedAssociationsByMasterIdAndDetailId));
   }
 
   @Override
@@ -122,7 +122,7 @@ public class MappingProfileServiceImpl extends AbstractProfileService<MappingPro
     List<Future<Boolean>> futures = profileDto.getAddedRelations().stream()
       .filter(profileAssociation -> profileAssociation.getMasterProfileType().equals(ACTION_PROFILE))
       .map(ProfileAssociation::getMasterWrapperId)
-      .map(actionProfileId -> profileAssociationService.deleteByMasterId(actionProfileId, ContentType.ACTION_PROFILE,
+      .map(actionProfileId -> profileAssociationService.deleteByMasterWrapperId(actionProfileId, ContentType.ACTION_PROFILE,
         ContentType.MAPPING_PROFILE, tenantId))
       .collect(Collectors.toList());
 

--- a/mod-di-converter-storage-server/src/main/java/org/folio/services/ProfileService.java
+++ b/mod-di-converter-storage-server/src/main/java/org/folio/services/ProfileService.java
@@ -3,11 +3,8 @@ package org.folio.services;
 import io.vertx.core.Future;
 import org.folio.rest.impl.util.OkapiConnectionParams;
 import org.folio.rest.jaxrs.model.EntityTypeCollection;
-import org.folio.rest.jaxrs.model.ProfileAssociation;
 
-import java.util.List;
 import java.util.Optional;
-import java.util.function.BiFunction;
 
 /**
  * Generic Profile Service
@@ -58,17 +55,6 @@ public interface ProfileService<T, S, D> {
    * @return future with updated entity
    */
   Future<T> updateProfile(D profile, OkapiConnectionParams params);
-
-   /**
-   * Updates D with given id
-   *
-   * @param profile Profile to update
-   * @param params  {@link OkapiConnectionParams}
-   * @param deleteAssociationsFunction function for profile associations deletion
-   * @return future with updated entity
-   */
-  Future<T> updateProfile(D profile, OkapiConnectionParams params,
-                          BiFunction<List<ProfileAssociation>, String, Future<Boolean>> deleteAssociationsFunction);
 
   /**
    * Search in database profile with the same name which contains in specified profile

--- a/mod-di-converter-storage-server/src/main/java/org/folio/services/ProfileService.java
+++ b/mod-di-converter-storage-server/src/main/java/org/folio/services/ProfileService.java
@@ -3,8 +3,11 @@ package org.folio.services;
 import io.vertx.core.Future;
 import org.folio.rest.impl.util.OkapiConnectionParams;
 import org.folio.rest.jaxrs.model.EntityTypeCollection;
+import org.folio.rest.jaxrs.model.ProfileAssociation;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.function.BiFunction;
 
 /**
  * Generic Profile Service
@@ -48,13 +51,24 @@ public interface ProfileService<T, S, D> {
   Future<T> saveProfile(D profile, OkapiConnectionParams params);
 
   /**
-   * Updates T with given id
+   * Updates D with given id
    *
    * @param profile Profile to update
    * @param params  {@link OkapiConnectionParams}
    * @return future with updated entity
    */
   Future<T> updateProfile(D profile, OkapiConnectionParams params);
+
+   /**
+   * Updates D with given id
+   *
+   * @param profile Profile to update
+   * @param params  {@link OkapiConnectionParams}
+   * @param deleteAssociationsFunction function for profile associations deletion
+   * @return future with updated entity
+   */
+  Future<T> updateProfile(D profile, OkapiConnectionParams params,
+                          BiFunction<List<ProfileAssociation>, String, Future<Boolean>> deleteAssociationsFunction);
 
   /**
    * Search in database profile with the same name which contains in specified profile

--- a/mod-di-converter-storage-server/src/main/java/org/folio/services/association/CommonProfileAssociationService.java
+++ b/mod-di-converter-storage-server/src/main/java/org/folio/services/association/CommonProfileAssociationService.java
@@ -207,8 +207,13 @@ public class CommonProfileAssociationService implements ProfileAssociationServic
   }
 
   @Override
-  public Future<Boolean> deleteByMasterId(String wrapperId, ContentType masterType, ContentType detailType, String tenantId) {
-    return profileAssociationDao.deleteByMasterId(wrapperId, masterType, detailType, tenantId);
+  public Future<Boolean> deleteByMasterWrapperId(String wrapperId, ContentType masterType, ContentType detailType, String tenantId) {
+    return profileAssociationDao.deleteByMasterWrapperId(wrapperId, masterType, detailType, tenantId);
+  }
+
+  @Override
+  public Future<Boolean> deleteByMasterIdAndDetailId(String masterId, String detailId, ContentType masterType, ContentType detailType, String tenantId) {
+    return profileAssociationDao.deleteByMasterIdAndDetailId(masterId, detailId, masterType, detailType, tenantId);
   }
 
   /**

--- a/mod-di-converter-storage-server/src/main/java/org/folio/services/association/ProfileAssociationService.java
+++ b/mod-di-converter-storage-server/src/main/java/org/folio/services/association/ProfileAssociationService.java
@@ -122,11 +122,23 @@ public interface ProfileAssociationService { //NOSONAR
   /**
    * Delete profile associations for particular master profile by wrapperId
    *
-   * @param wrapperId   - master profile id
+   * @param wrapperId   - master profile wrapper id
    * @param masterType - master profile type
    * @param detailType - detail profile type
    * @param tenantId   - tenant id
    * @return future with boolean
    */
-  Future<Boolean> deleteByMasterId(String wrapperId, ContentType masterType, ContentType detailType, String tenantId);
+  Future<Boolean> deleteByMasterWrapperId(String wrapperId, ContentType masterType, ContentType detailType, String tenantId);
+
+  /**
+   * Delete ProfileAssociation by masterId and detailId
+   *
+   * @param masterId     - UUID of masterProfile
+   * @param detailId     - UUID of detailProfile
+   * @param masterType   - master Profile Type
+   * @param detailType   - detail Profile Type
+   * @param tenantId     - tenant id
+   * @return - boolean result of operation
+   */
+  Future<Boolean> deleteByMasterIdAndDetailId(String masterId, String detailId, ContentType masterType, ContentType detailType, String tenantId);
 }

--- a/mod-di-converter-storage-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-di-converter-storage-server/src/main/resources/templates/db_scripts/schema.json
@@ -289,6 +289,16 @@
           "targetTable": "profile_wrappers",
           "tOps": "ADD"
         }
+      ],
+      "index": [
+        {
+          "fieldName": "masterProfileId",
+          "tOps": "ADD"
+        },
+        {
+          "fieldName": "detailProfileId",
+          "tOps": "ADD"
+        }
       ]
     }
   ],

--- a/mod-di-converter-storage-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-di-converter-storage-server/src/main/resources/templates/db_scripts/schema.json
@@ -293,11 +293,13 @@
       "index": [
         {
           "fieldName": "masterProfileId",
-          "tOps": "ADD"
+          "tOps": "ADD",
+          "removeAccents": false
         },
         {
           "fieldName": "detailProfileId",
-          "tOps": "ADD"
+          "tOps": "ADD",
+          "removeAccents": false
         }
       ]
     }


### PR DESCRIPTION
## Purpose
[MODDICONV-346](https://issues.folio.org/browse/MODDICONV-346) User can not unlink associated action profiles

## Approach
Unlinking of profiles was done base on masterWrapperId/detailWrapperId which were not available in update request for action+mapping profiles. Giving that mapping to action relationship in one-to-one it's possible to unlink them based on masterProfileId/detailProfileId themselves. Corresponding deletion support was added and used by MappingProfileService and ActionProfileService
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

## Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
