### PR TITLE
MODDICONV-355: Unlinking of action profile works not as expected when same action profile is present more than once in job profile

### DIFF
--- a/mod-di-converter-storage-server/src/main/java/org/folio/dao/association/CommonProfileAssociationDao.java
+++ b/mod-di-converter-storage-server/src/main/java/org/folio/dao/association/CommonProfileAssociationDao.java
@@ -44,8 +44,7 @@ public class CommonProfileAssociationDao implements ProfileAssociationDao {
   private static final String JOB_PROFILE_ID_FIELD = "jobProfileId";
   private static final String CRITERIA_BY_MASTER_ID_AND_DETAIL_ID_WHERE_CLAUSE =
     "WHERE (left(lower(%1$s.jsonb->>'masterProfileId'),600) LIKE lower('%2$s')) " +
-      "AND (lower(%1$s.jsonb->>'detailProfileId') LIKE lower('%3$s')) " +
-      "AND (lower(%1$s.jsonb->>'reactTo') LIKE lower('%4$s'))";
+      "AND (lower(%1$s.jsonb->>'detailProfileId') LIKE lower('%3$s'))";
 
   private static final String CRITERIA_BY_REACT_TO_WHERE_CLAUSE =
     "WHERE (lower(%1$s.jsonb->>'reactTo') LIKE lower('%2$s'))";
@@ -175,13 +174,13 @@ public class CommonProfileAssociationDao implements ProfileAssociationDao {
 
   @Override
   public Future<Boolean> deleteByMasterIdAndDetailId(String masterId, String detailId, ContentType masterType,
-                                                     ContentType detailType, ReactToType reactTo, String tenantId) {
+                                                     ContentType detailType, String tenantId) {
     Promise<RowSet<Row>> promise = Promise.promise();
     try {
       /* Setting WHERE clause explicitly here because incorrect query is created by CQLWrapper by default due to
       presence of 2 definitions of mapping tables in schema.json and the query is generated based on outdated definition */
       CQLWrapper filter = new CQLWrapper().setWhereClause(String.format(CRITERIA_BY_MASTER_ID_AND_DETAIL_ID_WHERE_CLAUSE,
-        getAssociationTableName(masterType, detailType), masterId, detailId, reactTo.value()));
+        getAssociationTableName(masterType, detailType), masterId, detailId));
       pgClientFactory.createInstance(tenantId).delete(getAssociationTableName(masterType, detailType), filter, promise);
     } catch (Exception e) {
       LOGGER.warn("deleteByMasterIdAndDetailId:: Error deleting by master id {} and detail id {}", masterId, detailId, e);

--- a/mod-di-converter-storage-server/src/main/java/org/folio/dao/association/CommonProfileAssociationDao.java
+++ b/mod-di-converter-storage-server/src/main/java/org/folio/dao/association/CommonProfileAssociationDao.java
@@ -149,8 +149,10 @@ public class CommonProfileAssociationDao implements ProfileAssociationDao {
       CQLWrapper filter = getCQLWrapper(getAssociationTableName(masterType, detailType),
         MASTER_WRAPPER_ID_FIELD + "==" + masterWrapperId + " AND " + DETAIL_WRAPPER_ID_FIELD + "==" + detailWrapperId +
           // if jobProfileId field defined in jsonb - perform matching on it, if not - match all records.
-          " AND (" + JOB_PROFILE_ID_FIELD + "==" + jobProfileId + " OR (cql.allRecords=1 NOT " + JOB_PROFILE_ID_FIELD + "=\"\"))")
-        .setWhereClause(String.format(CRITERIA_BY_REACT_TO_WHERE_CLAUSE, getAssociationTableName(masterType, detailType), reactTo.value()));
+          " AND (" + JOB_PROFILE_ID_FIELD + "==" + jobProfileId + " OR (cql.allRecords=1 NOT " + JOB_PROFILE_ID_FIELD + "=\"\"))");
+      if (reactTo != null) {
+        filter.setWhereClause(String.format(CRITERIA_BY_REACT_TO_WHERE_CLAUSE, getAssociationTableName(masterType, detailType), reactTo.value()));
+      }
       pgClientFactory.createInstance(tenantId).delete(getAssociationTableName(masterType, detailType), filter, promise);
     } catch (Exception e) {
       LOGGER.warn("delete:: Error deleting by master wrapper id {} and detail wrapper id {}", masterWrapperId, detailWrapperId, e);

--- a/mod-di-converter-storage-server/src/main/java/org/folio/dao/association/CommonProfileAssociationDao.java
+++ b/mod-di-converter-storage-server/src/main/java/org/folio/dao/association/CommonProfileAssociationDao.java
@@ -11,6 +11,7 @@ import org.folio.rest.jaxrs.model.ProfileAssociation;
 import org.folio.rest.jaxrs.model.ProfileAssociationCollection;
 import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
 import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType;
+import org.folio.rest.jaxrs.model.ReactToType;
 import org.folio.rest.persist.Criteria.Criteria;
 import org.folio.rest.persist.Criteria.Criterion;
 import org.folio.rest.persist.cql.CQLWrapper;
@@ -43,7 +44,12 @@ public class CommonProfileAssociationDao implements ProfileAssociationDao {
   private static final String JOB_PROFILE_ID_FIELD = "jobProfileId";
   private static final String CRITERIA_BY_MASTER_ID_AND_DETAIL_ID_WHERE_CLAUSE =
     "WHERE (left(lower(%1$s.jsonb->>'masterProfileId'),600) LIKE lower('%2$s')) " +
-      "AND (lower(%1$s.jsonb->>'detailProfileId') LIKE lower('%3$s'))";
+      "AND (lower(%1$s.jsonb->>'detailProfileId') LIKE lower('%3$s')) " +
+      "AND (lower(%1$s.jsonb->>'reactTo') LIKE lower('%4$s'))";
+
+  private static final String CRITERIA_BY_REACT_TO_WHERE_CLAUSE =
+    "WHERE (lower(%1$s.jsonb->>'reactTo') LIKE lower('%2$s'))";
+
   private static final Logger LOGGER = LogManager.getLogger();
   private static final String CORRECT_PROFILE_ASSOCIATION_TYPES_MESSAGE = "Correct ProfileAssociation types: " +
     "ACTION_PROFILE_TO_ACTION_PROFILE, " +
@@ -137,14 +143,15 @@ public class CommonProfileAssociationDao implements ProfileAssociationDao {
   }
 
   @Override
-  public Future<Boolean> delete(String masterWrapperId, String detailWrapperId, ProfileSnapshotWrapper.ContentType masterType, ProfileSnapshotWrapper.ContentType detailType, String tenantId, String jobProfileId) {
+  public Future<Boolean> delete(String masterWrapperId, String detailWrapperId, ProfileSnapshotWrapper.ContentType masterType,
+                                ProfileSnapshotWrapper.ContentType detailType, String jobProfileId, ReactToType reactTo, String tenantId) {
     Promise<RowSet<Row>> promise = Promise.promise();
     try {
       CQLWrapper filter = getCQLWrapper(getAssociationTableName(masterType, detailType),
         MASTER_WRAPPER_ID_FIELD + "==" + masterWrapperId + " AND " + DETAIL_WRAPPER_ID_FIELD + "==" + detailWrapperId +
           // if jobProfileId field defined in jsonb - perform matching on it, if not - match all records.
-          " AND (" + JOB_PROFILE_ID_FIELD + "==" + jobProfileId + " OR (cql.allRecords=1 NOT " + JOB_PROFILE_ID_FIELD + "=\"\"))");
-
+          " AND (" + JOB_PROFILE_ID_FIELD + "==" + jobProfileId + " OR (cql.allRecords=1 NOT " + JOB_PROFILE_ID_FIELD + "=\"\"))")
+        .setWhereClause(String.format(CRITERIA_BY_REACT_TO_WHERE_CLAUSE, getAssociationTableName(masterType, detailType), reactTo.value()));
       pgClientFactory.createInstance(tenantId).delete(getAssociationTableName(masterType, detailType), filter, promise);
     } catch (Exception e) {
       LOGGER.warn("delete:: Error deleting by master wrapper id {} and detail wrapper id {}", masterWrapperId, detailWrapperId, e);
@@ -167,13 +174,14 @@ public class CommonProfileAssociationDao implements ProfileAssociationDao {
   }
 
   @Override
-  public Future<Boolean> deleteByMasterIdAndDetailId(String masterId, String detailId, ContentType masterType, ContentType detailType, String tenantId) {
+  public Future<Boolean> deleteByMasterIdAndDetailId(String masterId, String detailId, ContentType masterType,
+                                                     ContentType detailType, ReactToType reactTo, String tenantId) {
     Promise<RowSet<Row>> promise = Promise.promise();
     try {
       /* Setting WHERE clause explicitly here because incorrect query is created by CQLWrapper by default due to
       presence of 2 definitions of mapping tables in schema.json and the query is generated based on outdated definition */
       CQLWrapper filter = new CQLWrapper().setWhereClause(String.format(CRITERIA_BY_MASTER_ID_AND_DETAIL_ID_WHERE_CLAUSE,
-        getAssociationTableName(masterType, detailType), masterId, detailId));
+        getAssociationTableName(masterType, detailType), masterId, detailId, reactTo.value()));
       pgClientFactory.createInstance(tenantId).delete(getAssociationTableName(masterType, detailType), filter, promise);
     } catch (Exception e) {
       LOGGER.warn("deleteByMasterIdAndDetailId:: Error deleting by master id {} and detail id {}", masterId, detailId, e);

--- a/mod-di-converter-storage-server/src/main/java/org/folio/dao/association/ProfileAssociationDao.java
+++ b/mod-di-converter-storage-server/src/main/java/org/folio/dao/association/ProfileAssociationDao.java
@@ -103,5 +103,5 @@ public interface ProfileAssociationDao {
    * @return - boolean result of operation
    */
   Future<Boolean> deleteByMasterIdAndDetailId(String masterId, String detailId, ProfileSnapshotWrapper.ContentType masterType,
-                                              ProfileSnapshotWrapper.ContentType detailType, ReactToType reactTo, String tenantId);
+                                              ProfileSnapshotWrapper.ContentType detailType, String tenantId);
 }

--- a/mod-di-converter-storage-server/src/main/java/org/folio/dao/association/ProfileAssociationDao.java
+++ b/mod-di-converter-storage-server/src/main/java/org/folio/dao/association/ProfileAssociationDao.java
@@ -4,6 +4,7 @@ import io.vertx.core.Future;
 import org.folio.rest.jaxrs.model.ProfileAssociation;
 import org.folio.rest.jaxrs.model.ProfileAssociationCollection;
 import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
+import org.folio.rest.jaxrs.model.ReactToType;
 
 import java.util.Optional;
 
@@ -77,7 +78,8 @@ public interface ProfileAssociationDao {
    * @param jobProfileId - job profile id (optional)
    * @return - boolean result of operation
    */
-  Future<Boolean> delete(String masterWrapperId, String detailWrapperId, ProfileSnapshotWrapper.ContentType masterType, ProfileSnapshotWrapper.ContentType detailType, String tenantId, String jobProfileId);
+  Future<Boolean> delete(String masterWrapperId, String detailWrapperId, ProfileSnapshotWrapper.ContentType masterType,
+                         ProfileSnapshotWrapper.ContentType detailType, String jobProfileId, ReactToType reactTo, String tenantId);
 
   /**
    * Delete profile associations for particular master profile by wrapperId
@@ -100,5 +102,6 @@ public interface ProfileAssociationDao {
    * @param tenantId     - tenant id
    * @return - boolean result of operation
    */
-  Future<Boolean> deleteByMasterIdAndDetailId(String masterId, String detailId, ProfileSnapshotWrapper.ContentType masterType, ProfileSnapshotWrapper.ContentType detailType, String tenantId);
+  Future<Boolean> deleteByMasterIdAndDetailId(String masterId, String detailId, ProfileSnapshotWrapper.ContentType masterType,
+                                              ProfileSnapshotWrapper.ContentType detailType, ReactToType reactTo, String tenantId);
 }

--- a/mod-di-converter-storage-server/src/main/java/org/folio/services/AbstractProfileService.java
+++ b/mod-di-converter-storage-server/src/main/java/org/folio/services/AbstractProfileService.java
@@ -149,7 +149,7 @@ public abstract class AbstractProfileService<T, S, D> implements ProfileService<
                                                                   ContentType detailContentType,
                                                                   String tenantId) {
     return profileAssociationService.deleteByMasterIdAndDetailId(association.getMasterProfileId(),
-      association.getDetailProfileId(), masterContentType, detailContentType, association.getReactTo(), tenantId);
+      association.getDetailProfileId(), masterContentType, detailContentType, tenantId);
   }
 
   private Future<Boolean> saveRelatedAssociations(List<ProfileAssociation> profileAssociations, String tenantId) {

--- a/mod-di-converter-storage-server/src/main/java/org/folio/services/AbstractProfileService.java
+++ b/mod-di-converter-storage-server/src/main/java/org/folio/services/AbstractProfileService.java
@@ -132,12 +132,11 @@ public abstract class AbstractProfileService<T, S, D> implements ProfileService<
     ProfileSnapshotWrapper.ContentType detailContentType =
       ProfileSnapshotWrapper.ContentType.fromValue(association.getDetailProfileType().name());
 
-    LOGGER.debug("deleteAssociation: masterContentType={}, detailContentType={}, reactTo={}",
-      masterContentType.value(), detailContentType.value(), association.getReactTo().value());
-
     if (association.getMasterProfileType() == ACTION_PROFILE && association.getDetailProfileType() == MAPPING_PROFILE) {
       return deleteMappingToActionProfileAssociation(association, masterContentType, detailContentType, tenantId);
     } else {
+      LOGGER.debug("deleteAssociation: masterContentType={}, detailContentType={}, reactTo={}",
+        masterContentType.value(), detailContentType.value(), association.getReactTo());
       return profileAssociationService.delete(association.getMasterWrapperId(),
         association.getDetailWrapperId(), masterContentType, detailContentType, association.getJobProfileId(),
         association.getReactTo(), tenantId);

--- a/mod-di-converter-storage-server/src/main/java/org/folio/services/association/CommonProfileAssociationService.java
+++ b/mod-di-converter-storage-server/src/main/java/org/folio/services/association/CommonProfileAssociationService.java
@@ -26,6 +26,7 @@ import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
 import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType;
 import org.folio.rest.jaxrs.model.ProfileType;
 import org.folio.rest.jaxrs.model.ProfileWrapper;
+import org.folio.rest.jaxrs.model.ReactToType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -202,8 +203,9 @@ public class CommonProfileAssociationService implements ProfileAssociationServic
   }
 
   @Override
-  public Future<Boolean> delete(String masterWrapperId, String detailWrapperId, ContentType masterType, ContentType detailType, String tenantId, String jobProfileId) {
-    return profileAssociationDao.delete(masterWrapperId, detailWrapperId, masterType, detailType, tenantId, jobProfileId);
+  public Future<Boolean> delete(String masterWrapperId, String detailWrapperId, ContentType masterType, ContentType detailType,
+                                String jobProfileId, ReactToType reactTo, String tenantId) {
+    return profileAssociationDao.delete(masterWrapperId, detailWrapperId, masterType, detailType, jobProfileId, reactTo, tenantId);
   }
 
   @Override
@@ -212,8 +214,13 @@ public class CommonProfileAssociationService implements ProfileAssociationServic
   }
 
   @Override
-  public Future<Boolean> deleteByMasterIdAndDetailId(String masterId, String detailId, ContentType masterType, ContentType detailType, String tenantId) {
-    return profileAssociationDao.deleteByMasterIdAndDetailId(masterId, detailId, masterType, detailType, tenantId);
+  public Future<Boolean> deleteByMasterIdAndDetailId(String masterId, String detailId, ContentType masterType,
+                                                     ContentType detailType, ReactToType reactTo,
+                                                     String tenantId) {
+    LOGGER.info("deleteByMasterIdAndDetailId : masterId={}, detailId={}, masterType={}, detailType={}, reactTo={}",
+      masterId, detailId, masterType.value(), detailType.value(), reactTo.value());
+
+    return profileAssociationDao.deleteByMasterIdAndDetailId(masterId, detailId, masterType, detailType, reactTo, tenantId);
   }
 
   /**

--- a/mod-di-converter-storage-server/src/main/java/org/folio/services/association/CommonProfileAssociationService.java
+++ b/mod-di-converter-storage-server/src/main/java/org/folio/services/association/CommonProfileAssociationService.java
@@ -215,12 +215,10 @@ public class CommonProfileAssociationService implements ProfileAssociationServic
 
   @Override
   public Future<Boolean> deleteByMasterIdAndDetailId(String masterId, String detailId, ContentType masterType,
-                                                     ContentType detailType, ReactToType reactTo,
-                                                     String tenantId) {
-    LOGGER.info("deleteByMasterIdAndDetailId : masterId={}, detailId={}, masterType={}, detailType={}, reactTo={}",
-      masterId, detailId, masterType.value(), detailType.value(), reactTo.value());
-
-    return profileAssociationDao.deleteByMasterIdAndDetailId(masterId, detailId, masterType, detailType, reactTo, tenantId);
+                                                     ContentType detailType, String tenantId) {
+    LOGGER.debug("deleteByMasterIdAndDetailId : masterId={}, detailId={}, masterType={}, detailType={}",
+      masterId, detailId, masterType.value(), detailType.value());
+    return profileAssociationDao.deleteByMasterIdAndDetailId(masterId, detailId, masterType, detailType, tenantId);
   }
 
   /**

--- a/mod-di-converter-storage-server/src/main/java/org/folio/services/association/ProfileAssociationService.java
+++ b/mod-di-converter-storage-server/src/main/java/org/folio/services/association/ProfileAssociationService.java
@@ -143,6 +143,5 @@ public interface ProfileAssociationService { //NOSONAR
    * @return - boolean result of operation
    */
   Future<Boolean> deleteByMasterIdAndDetailId(String masterId, String detailId, ContentType masterType,
-                                              ContentType detailType, ReactToType reactTo,
-                                              String tenantId);
+                                              ContentType detailType, String tenantId);
 }

--- a/mod-di-converter-storage-server/src/main/java/org/folio/services/association/ProfileAssociationService.java
+++ b/mod-di-converter-storage-server/src/main/java/org/folio/services/association/ProfileAssociationService.java
@@ -6,6 +6,7 @@ import org.folio.rest.jaxrs.model.ProfileAssociation;
 import org.folio.rest.jaxrs.model.ProfileAssociationCollection;
 import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
 import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType;
+import org.folio.rest.jaxrs.model.ReactToType;
 
 import java.util.List;
 import java.util.Optional;
@@ -117,7 +118,8 @@ public interface ProfileAssociationService { //NOSONAR
    * @param jobProfileId - job profile id (optional)
    * @return - boolean result of operation
    */
-  Future<Boolean> delete(String masterWrapperId, String detailWrapperId, ContentType masterType, ContentType detailType, String tenantId, String jobProfileId);
+  Future<Boolean> delete(String masterWrapperId, String detailWrapperId, ContentType masterType, ContentType detailType, String jobProfileId,
+                         ReactToType reactTo, String tenantId);
 
   /**
    * Delete profile associations for particular master profile by wrapperId
@@ -140,5 +142,7 @@ public interface ProfileAssociationService { //NOSONAR
    * @param tenantId     - tenant id
    * @return - boolean result of operation
    */
-  Future<Boolean> deleteByMasterIdAndDetailId(String masterId, String detailId, ContentType masterType, ContentType detailType, String tenantId);
+  Future<Boolean> deleteByMasterIdAndDetailId(String masterId, String detailId, ContentType masterType,
+                                              ContentType detailType, ReactToType reactTo,
+                                              String tenantId);
 }

--- a/mod-di-converter-storage-server/src/test/java/org/folio/rest/impl/ActionProfileTest.java
+++ b/mod-di-converter-storage-server/src/test/java/org/folio/rest/impl/ActionProfileTest.java
@@ -16,7 +16,6 @@ import org.folio.rest.jaxrs.model.ProfileAssociation;
 import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
 import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType;
 import org.folio.rest.jaxrs.model.ProfileType;
-import org.folio.rest.jaxrs.model.ReactToType;
 import org.folio.rest.jaxrs.model.Tags;
 import org.folio.rest.persist.Criteria.Criterion;
 import org.folio.rest.persist.PostgresClient;
@@ -380,8 +379,7 @@ public class ActionProfileTest extends AbstractRestVerticleTest {
       .withAddedRelations(List.of(new ProfileAssociation()
         .withMasterProfileType(ProfileType.ACTION_PROFILE)
         .withMasterProfileId(actionProfileDto.getId())
-        .withDetailProfileType(ProfileType.MAPPING_PROFILE)
-        .withReactTo(ReactToType.MATCH))));
+        .withDetailProfileType(ProfileType.MAPPING_PROFILE))));
 
     RestAssured.given()
       .spec(spec)
@@ -390,7 +388,6 @@ public class ActionProfileTest extends AbstractRestVerticleTest {
           .withMasterProfileType(ProfileType.ACTION_PROFILE)
           .withMasterProfileId(actionProfileDto.getProfile().getId())
           .withDetailProfileType(ProfileType.MAPPING_PROFILE)
-          .withReactTo(ReactToType.MATCH)
           .withDetailProfileId(mappingProfileDto.getAddedRelations().get(0).getDetailProfileId()))))
       .when()
       .put(ACTION_PROFILES_PATH + "/" + actionProfileDto.getProfile().getId())
@@ -483,8 +480,7 @@ public class ActionProfileTest extends AbstractRestVerticleTest {
           .withMasterProfileType(ProfileType.ACTION_PROFILE)
           .withMasterProfileId(actionProfileDto1.getId())
           .withDetailProfileType(ProfileType.MAPPING_PROFILE)
-          .withDetailProfileId(associatedMappingProfile.getId())
-          .withReactTo(ReactToType.MATCH))))
+          .withDetailProfileId(associatedMappingProfile.getId()))))
       .when()
       .put(ACTION_PROFILES_PATH + "/" + actionProfileDto1.getProfile().getId())
       .then()
@@ -541,8 +537,7 @@ public class ActionProfileTest extends AbstractRestVerticleTest {
           .withMasterProfileType(ProfileType.ACTION_PROFILE)
           .withMasterProfileId(actionProfileId)
           .withDetailProfileType(ProfileType.MAPPING_PROFILE)
-          .withDetailProfileId(mappingProfileId)
-          .withReactTo(ReactToType.MATCH))))
+          .withDetailProfileId(mappingProfileId))))
       .when()
       .put(ACTION_PROFILES_PATH + "/" + actionProfileDto.getProfile().getId())
       .then()

--- a/mod-di-converter-storage-server/src/test/java/org/folio/rest/impl/ActionProfileTest.java
+++ b/mod-di-converter-storage-server/src/test/java/org/folio/rest/impl/ActionProfileTest.java
@@ -16,6 +16,7 @@ import org.folio.rest.jaxrs.model.ProfileAssociation;
 import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
 import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType;
 import org.folio.rest.jaxrs.model.ProfileType;
+import org.folio.rest.jaxrs.model.ReactToType;
 import org.folio.rest.jaxrs.model.Tags;
 import org.folio.rest.persist.Criteria.Criterion;
 import org.folio.rest.persist.PostgresClient;
@@ -379,7 +380,8 @@ public class ActionProfileTest extends AbstractRestVerticleTest {
       .withAddedRelations(List.of(new ProfileAssociation()
         .withMasterProfileType(ProfileType.ACTION_PROFILE)
         .withMasterProfileId(actionProfileDto.getId())
-        .withDetailProfileType(ProfileType.MAPPING_PROFILE))));
+        .withDetailProfileType(ProfileType.MAPPING_PROFILE)
+        .withReactTo(ReactToType.MATCH))));
 
     RestAssured.given()
       .spec(spec)
@@ -388,6 +390,7 @@ public class ActionProfileTest extends AbstractRestVerticleTest {
           .withMasterProfileType(ProfileType.ACTION_PROFILE)
           .withMasterProfileId(actionProfileDto.getProfile().getId())
           .withDetailProfileType(ProfileType.MAPPING_PROFILE)
+          .withReactTo(ReactToType.MATCH)
           .withDetailProfileId(mappingProfileDto.getAddedRelations().get(0).getDetailProfileId()))))
       .when()
       .put(ACTION_PROFILES_PATH + "/" + actionProfileDto.getProfile().getId())
@@ -480,7 +483,8 @@ public class ActionProfileTest extends AbstractRestVerticleTest {
           .withMasterProfileType(ProfileType.ACTION_PROFILE)
           .withMasterProfileId(actionProfileDto1.getId())
           .withDetailProfileType(ProfileType.MAPPING_PROFILE)
-          .withDetailProfileId(associatedMappingProfile.getId()))))
+          .withDetailProfileId(associatedMappingProfile.getId())
+          .withReactTo(ReactToType.MATCH))))
       .when()
       .put(ACTION_PROFILES_PATH + "/" + actionProfileDto1.getProfile().getId())
       .then()
@@ -537,7 +541,8 @@ public class ActionProfileTest extends AbstractRestVerticleTest {
           .withMasterProfileType(ProfileType.ACTION_PROFILE)
           .withMasterProfileId(actionProfileId)
           .withDetailProfileType(ProfileType.MAPPING_PROFILE)
-          .withDetailProfileId(mappingProfileId))))
+          .withDetailProfileId(mappingProfileId)
+          .withReactTo(ReactToType.MATCH))))
       .when()
       .put(ACTION_PROFILES_PATH + "/" + actionProfileDto.getProfile().getId())
       .then()

--- a/mod-di-converter-storage-server/src/test/java/org/folio/rest/impl/JobProfileTest.java
+++ b/mod-di-converter-storage-server/src/test/java/org/folio/rest/impl/JobProfileTest.java
@@ -22,6 +22,7 @@ import org.folio.rest.jaxrs.model.ProfileAssociation;
 import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
 import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType;
 import org.folio.rest.jaxrs.model.ProfileType;
+import org.folio.rest.jaxrs.model.ReactToType;
 import org.folio.rest.jaxrs.model.Tags;
 import org.folio.rest.persist.Criteria.Criterion;
 import org.folio.rest.persist.PostgresClient;
@@ -446,6 +447,7 @@ public class JobProfileTest extends AbstractRestVerticleTest {
         .withMasterProfileId(jobProfileToUpdate.getProfile().getId())
         .withMasterProfileType(ProfileType.JOB_PROFILE)
         .withDetailProfileType(ProfileType.MATCH_PROFILE)
+        .withReactTo(ReactToType.MATCH)
         .withOrder(1),
       JOB_PROFILE, MATCH_PROFILE);
 

--- a/mod-di-converter-storage-server/src/test/java/org/folio/rest/impl/MappingProfileTest.java
+++ b/mod-di-converter-storage-server/src/test/java/org/folio/rest/impl/MappingProfileTest.java
@@ -19,6 +19,7 @@ import org.folio.rest.jaxrs.model.MappingRule;
 import org.folio.rest.jaxrs.model.ProfileAssociation;
 import org.folio.rest.jaxrs.model.ProfileType;
 import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
+import org.folio.rest.jaxrs.model.ReactToType;
 import org.folio.rest.jaxrs.model.Tags;
 import org.folio.rest.persist.Criteria.Criterion;
 import org.folio.rest.persist.PostgresClient;
@@ -63,7 +64,7 @@ public class MappingProfileTest extends AbstractRestVerticleTest {
   private static final String PROFILE_WRAPPERS_TABLE = "profile_wrappers";
 
   private static final String MAPPING_PROFILE_UUID = "608ab35e-5f8b-49c3-bcf1-1fb5e57d5130";
-  private List<String> defaultMappingProfileIds = Arrays.asList(
+  private final List<String> defaultMappingProfileIds = Arrays.asList(
     "d0ebbc2e-2f0f-11eb-adc1-0242ac120002", //OCLC_CREATE_MAPPING_PROFILE_ID
     "862000b9-84ea-4cae-a223-5fc0552f2b42", //OCLC_UPDATE_MAPPING_PROFILE_ID
     "f90864ef-8030-480f-a43f-8cdd21233252", //OCLC_UPDATE_MARC_BIB_MAPPING_PROFILE_ID
@@ -101,7 +102,7 @@ public class MappingProfileTest extends AbstractRestVerticleTest {
       .withIncomingRecordType(EntityType.MARC_BIBLIOGRAPHIC)
       .withExistingRecordType(EntityType.INSTANCE));
 
-  private static MappingProfileUpdateDto mappingProfileNotEmptyChildAndParent = new MappingProfileUpdateDto()
+  private static final MappingProfileUpdateDto mappingProfileNotEmptyChildAndParent = new MappingProfileUpdateDto()
     .withProfile(new MappingProfile()
       .withName("Mapping profile with child and parent")
       .withIncomingRecordType(EntityType.MARC_BIBLIOGRAPHIC)
@@ -809,6 +810,7 @@ public class MappingProfileTest extends AbstractRestVerticleTest {
       .withAddedRelations(List.of(new ProfileAssociation()
         .withMasterProfileType(ProfileType.ACTION_PROFILE)
         .withMasterProfileId(actionProfileDto.getId())
+        .withReactTo(ReactToType.MATCH)
         .withDetailProfileType(ProfileType.MAPPING_PROFILE))));
 
     RestAssured.given()
@@ -824,6 +826,7 @@ public class MappingProfileTest extends AbstractRestVerticleTest {
           .withMasterProfileType(ProfileType.ACTION_PROFILE)
           .withMasterProfileId(actionProfileDto.getProfile().getId())
           .withDetailProfileType(ProfileType.MAPPING_PROFILE)
+          .withReactTo(ReactToType.MATCH)
           .withDetailProfileId(mappingProfileDto.getAddedRelations().get(0).getDetailProfileId()))))
       .when()
       .put(MAPPING_PROFILES_PATH + "/" + mappingProfileDto.getProfile().getId())
@@ -863,7 +866,8 @@ public class MappingProfileTest extends AbstractRestVerticleTest {
       .withAddedRelations(List.of(new ProfileAssociation()
         .withMasterProfileType(ProfileType.ACTION_PROFILE)
         .withMasterProfileId(actionProfileDto.getId())
-        .withDetailProfileType(ProfileType.MAPPING_PROFILE))));
+        .withDetailProfileType(ProfileType.MAPPING_PROFILE)
+        .withReactTo(ReactToType.MATCH))));
 
     String actionProfileWrapperId = mappingProfileDto.getAddedRelations().get(0).getMasterWrapperId();
     String actionProfileId = actionProfileDto.getId();
@@ -882,6 +886,7 @@ public class MappingProfileTest extends AbstractRestVerticleTest {
           .withMasterProfileType(ProfileType.ACTION_PROFILE)
           .withMasterProfileId(actionProfileId)
           .withDetailProfileType(ProfileType.MAPPING_PROFILE)
+          .withReactTo(ReactToType.MATCH)
           .withDetailProfileId(mappingProfileId))))
       .when()
       .put(MAPPING_PROFILES_PATH + "/" + mappingProfileDto.getProfile().getId())


### PR DESCRIPTION
## Purpose
When the same action profile needed to be linked several times to the same job profile, further unlinking for it works not as expected

## Approach
the "reactTo" parameter was added to the search to remove associations more accurately

## Learning
[MODDICONV-355](https://issues.folio.org/browse/MODDICONV-355)