### PR TITLE
MODDICONV-344: Default Create Instance Action profile migrated with errors

### DIFF
--- a/mod-di-converter-storage-server/src/main/java/org/folio/services/AbstractProfileService.java
+++ b/mod-di-converter-storage-server/src/main/java/org/folio/services/AbstractProfileService.java
@@ -199,7 +199,7 @@ public abstract class AbstractProfileService<T, S, D> implements ProfileService<
     return profileWrapperDao.getWrapperByProfileId(actionProfileId, ACTION_PROFILE, tenantId)
       .compose(profileWrappers -> {
         if (profileWrappers.size() == 0) {
-          return Future.failedFuture(new NotFoundException(format("Mapping Profile does NOT exist for this Action Profile with id '%s' ", actionProfileId)));
+          return Future.failedFuture(new NotFoundException(format("Wrapper does NOT exist for this Action Profile with id '%s' ", actionProfileId)));
         }
         actionProfileAssociation.setDetailWrapperId(profileWrappers.get(0).getId());
         return Future.succeededFuture();

--- a/mod-di-converter-storage-server/src/main/java/org/folio/services/AbstractProfileService.java
+++ b/mod-di-converter-storage-server/src/main/java/org/folio/services/AbstractProfileService.java
@@ -198,15 +198,11 @@ public abstract class AbstractProfileService<T, S, D> implements ProfileService<
     String actionProfileId = actionProfileAssociation.getDetailProfileId();
     return profileWrapperDao.getWrapperByProfileId(actionProfileId, ACTION_PROFILE, tenantId)
       .compose(profileWrappers -> {
-        if (profileWrappers.size() == 1) {
-          actionProfileAssociation.setDetailWrapperId(profileWrappers.get(0).getId());
-          return Future.succeededFuture();
+        if (profileWrappers.size() < 1) {
+          return Future.failedFuture(new NotFoundException(format("Mapping Profile does NOT exist for this Action Profile with id '%s' ", actionProfileId)));
         }
-        if (profileWrappers.size() > 1) {
-          actionProfileAssociation.setDetailWrapperId(profileWrappers.get(0).getId());
-          return Future.succeededFuture();
-        }
-        return Future.failedFuture(new NotFoundException(format("Mapping Profile does NOT exist for this Action Profile with id '%s' ", actionProfileId)));
+        actionProfileAssociation.setDetailWrapperId(profileWrappers.get(0).getId());
+        return Future.succeededFuture();
       });
   }
 

--- a/mod-di-converter-storage-server/src/main/java/org/folio/services/AbstractProfileService.java
+++ b/mod-di-converter-storage-server/src/main/java/org/folio/services/AbstractProfileService.java
@@ -16,6 +16,8 @@ import org.folio.rest.jaxrs.model.EntityTypeCollection;
 import org.folio.rest.jaxrs.model.ProfileAssociation;
 import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
 import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType;
+import org.folio.rest.jaxrs.model.ProfileType;
+import org.folio.rest.jaxrs.model.ProfileWrapper;
 import org.folio.rest.jaxrs.model.UserInfo;
 import org.folio.services.association.CommonProfileAssociationService;
 import org.folio.services.association.ProfileAssociationService;
@@ -156,42 +158,41 @@ public abstract class AbstractProfileService<T, S, D> implements ProfileService<
       return Future.succeededFuture(true);
     }
     Promise<Boolean> result = Promise.promise();
-    GenericCompositeFuture.all(fillProfileDataIfNeeded(profileAssociations, tenantId))
-      .onSuccess(r ->
-        associationService.wrapAssociationProfiles(profileAssociations, new ArrayList<>(), new HashMap<>(), tenantId)
-          .compose(e -> profileAssociationService.save(e, tenantId))
-          .onComplete(ar -> {
-            if (ar.succeeded()) {
-              result.complete(true);
-            } else {
-              result.fail(ar.cause());
-            }
-          })
-      ).onFailure(result::fail);
+    List<Future<List<ProfileWrapper>>> futures = new ArrayList<>();
+    fillProfileDataIfNeeded(profileAssociations, tenantId, futures);
+
+    GenericCompositeFuture.all(futures).onSuccess(r -> {
+      associationService.wrapAssociationProfiles(profileAssociations, new ArrayList<>(), new HashMap<>(), tenantId)
+        .compose(e -> profileAssociationService.save(e, tenantId))
+        .onComplete(ar -> {
+          if (ar.succeeded()) {
+            result.complete(true);
+          } else {
+            result.fail(ar.cause());
+          }
+        });
+    }).onFailure(result::fail);
     return result.future();
   }
 
-  private List<Future<Void>> fillProfileDataIfNeeded(List<ProfileAssociation> profileAssociations, String tenantId) {
-    List<Future<Void>> futures = new ArrayList<>();
-
-    int associationsAmount;
+  private void fillProfileDataIfNeeded(List<ProfileAssociation> profileAssociations, String tenantId,
+                                       List<Future<List<ProfileWrapper>>> futures) {
     for (int i = 0; i < profileAssociations.size(); i++) {
-      associationsAmount = i + 1;
-      ProfileAssociation profileAssociation = profileAssociations.get(i);
-      if (profileAssociation.getDetailProfileType() == ACTION_PROFILE &&
-        (profileAssociations.size() == associationsAmount ||
-          profileAssociations.get(associationsAmount).getMasterProfileType() != ACTION_PROFILE)) {
-
-        futures.add(fillActionProfileDetailWrapper(profileAssociation, tenantId));
-
-      } else if (profileAssociation.getMasterProfileType() == ACTION_PROFILE
-        && profileAssociation.getDetailProfileType() == MAPPING_PROFILE
-        && profileAssociation.getMasterWrapperId() == null) {
-
-        futures.add(fillActionProfileMasterWrapper(profileAssociation, tenantId));
+      if (profileAssociations.get(i).getDetailProfileType() == ProfileType.ACTION_PROFILE &&
+        (profileAssociations.size() == i + 1 || profileAssociations.get(i + 1).getMasterProfileType() != ProfileType.ACTION_PROFILE)) {
+        ProfileAssociation tmpActionProfileAssoc = profileAssociations.get(i);
+        String actionProfileId = profileAssociations.get(i).getDetailProfileId();
+        futures.add(profileWrapperDao.getWrapperByProfileId(actionProfileId, ProfileType.ACTION_PROFILE, tenantId)
+          .compose(o -> {
+            if (o.size() == 1) {
+              tmpActionProfileAssoc.setDetailWrapperId(o.get(0).getId());
+              return Future.succeededFuture();
+            } else {
+              return Future.failedFuture(new NotFoundException(format("Mapping Profile is NOT exists for this Action Profile with id '%s' ", actionProfileId)));
+            }
+          }));
       }
     }
-    return futures;
   }
 
   private Future<Void> fillActionProfileDetailWrapper(ProfileAssociation actionProfileAssociation, String tenantId) {

--- a/mod-di-converter-storage-server/src/main/java/org/folio/services/AbstractProfileService.java
+++ b/mod-di-converter-storage-server/src/main/java/org/folio/services/AbstractProfileService.java
@@ -198,7 +198,7 @@ public abstract class AbstractProfileService<T, S, D> implements ProfileService<
     String actionProfileId = actionProfileAssociation.getDetailProfileId();
     return profileWrapperDao.getWrapperByProfileId(actionProfileId, ACTION_PROFILE, tenantId)
       .compose(profileWrappers -> {
-        if (profileWrappers.size() < 1) {
+        if (profileWrappers.size() == 0) {
           return Future.failedFuture(new NotFoundException(format("Mapping Profile does NOT exist for this Action Profile with id '%s' ", actionProfileId)));
         }
         actionProfileAssociation.setDetailWrapperId(profileWrappers.get(0).getId());


### PR DESCRIPTION
## Purpose
After the migration process, a reused action profile is duplicated in a job profile.

## Approach
For fixing the current case "unlink" function should be used.

## Learning
[MODDICONV-344](https://issues.folio.org/browse/MODDICONV-344)
