### PR TITLE
MODDICONV-305 For Quesnelia (R2 2023) remove "permissions" interface dependency

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 2023-XX-XX 2.2.0
+* [MODDICONV-305](https://issues.folio.org/browse/MODDICONV-305) For Quesnelia (R2 2023) remove "permissions" interface dependency
+
 ## 2023-XX-XX 2.1.3
 * [MODDICONV-346](https://issues.folio.org/browse/MODDICONV-346) Fix unlinking for action-mapping associations
 * [MODDICONV-353](https://issues.folio.org/browse/MODDICONV-353) Add quickMARC - Default Create authority job profile

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -2,12 +2,6 @@
   "id": "${artifactId}-${version}",
   "replaces" : [ "mod-data-import-converter-storage" ],
   "name": "Data Import Converter Storage",
-  "requires" : [
-    {
-      "id" : "permissions",
-      "version" : "5.6"
-    }
-  ],
   "provides": [
     {
       "id": "data-import-converter-storage",


### PR DESCRIPTION
## Purpose
 For Quesnelia (R2 2023) remove "permissions" interface dependency [MODDICONV-305](https://issues.folio.org/browse/MODDICONV-305)

## Approach
remove permission interface dependency from descriptor
