### PR TITLE
MODDICONV-365: Fix 'uuid-ossp' extension use

### DIFF
--- a/mod-di-converter-storage-server/src/main/resources/templates/db_scripts/associations-migration/init_wrappers.sql
+++ b/mod-di-converter-storage-server/src/main/resources/templates/db_scripts/associations-migration/init_wrappers.sql
@@ -1,3 +1,5 @@
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp" WITH SCHEMA public;
+
 /*
 This script will migrate job profiles to utilize profile wrappers. The order of DML is important to ensure consistent
 state before and after migration.


### PR DESCRIPTION
## Purpose
ERROR:  function public.uuid_generate_v4() does not exist at character 232

## Approach
Enable 'uuid-ossp' extension

## Learning
[MODDICONV-365](https://folio-org.atlassian.net/browse/MODDICONV-365)