### PR TITLE
MODDICORE-398: Upgrade mod-di-converter-storage to RMB 35.2.0, Vertx 4.5.4

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,12 +1,8 @@
-## 2024-03-XX 2.2.2
+## 2024-03-XX 2.2.0
 * [MODDICORE-398](https://folio-org.atlassian.net/browse/MODDICORE-398) Upgrade mod-di-converter-storage to RMB 35.2.0, Vert.x 4.5.4
-
-## 2024-02-XX 2.2.1
 * [MODDICONV-334](https://folio-org.atlassian.net/browse/MODDICONV-334) Disallow linking MARC Update action to a MARC Modify
 * [MODDICONV-367](https://folio-org.atlassian.net/browse/MODDICONV-367) Disallow action profile creation for MARCbib record with 'Create' action type
 * [MODDICONV-294](https://folio-org.atlassian.net/browse/MODDICONV-294) Disallow creation of JobProfile containing Update without Match
-
-## 2023-XX-XX 2.2.0
 * [MODDICONV-305](https://issues.folio.org/browse/MODDICONV-305) For Quesnelia (R2 2023) remove "permissions" interface dependency
 
 ## 2023-XX-XX 2.1.3

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 2024-03-XX 2.2.2
+* [MODDICORE-398](https://folio-org.atlassian.net/browse/MODDICORE-398) Upgrade mod-di-converter-storage to RMB 35.2.0, Vert.x 4.5.4
+
 ## 2024-02-XX 2.2.1
 * [MODDICONV-334](https://folio-org.atlassian.net/browse/MODDICONV-334) Disallow linking MARC Update action to a MARC Modify
 * [MODDICONV-367](https://folio-org.atlassian.net/browse/MODDICONV-367) Disallow action profile creation for MARCbib record with 'Create' action type

--- a/mod-di-converter-storage-server/pom.xml
+++ b/mod-di-converter-storage-server/pom.xml
@@ -58,7 +58,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.12.0</version>
+      <version>3.14.0</version>
     </dependency>
     <dependency>
       <groupId>org.folio</groupId>
@@ -73,7 +73,7 @@
     <dependency>
       <groupId>com.github.ben-manes.caffeine</groupId>
       <artifactId>caffeine</artifactId>
-      <version>3.1.2</version>
+      <version>3.1.8</version>
     </dependency>
     <dependency>
       <groupId>com.github.tomakehurst</groupId>
@@ -115,7 +115,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.1</version>
         <configuration>
-          <release>11</release>
+          <release>17</release>
           <encoding>UTF-8</encoding>
         </configuration>
       </plugin>
@@ -123,7 +123,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
-        <version>3.2.0</version>
+        <version>3.5.0</version>
         <executions>
           <execution>
             <id>add_generated_sources_folder</id>
@@ -318,7 +318,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.2</version>
+        <version>3.2.5</version>
         <configuration>
           <useSystemClassLoader>false</useSystemClassLoader>
         </configuration>

--- a/mod-di-converter-storage-server/src/main/java/org/folio/services/snapshot/ProfileSnapshotServiceImpl.java
+++ b/mod-di-converter-storage-server/src/main/java/org/folio/services/snapshot/ProfileSnapshotServiceImpl.java
@@ -21,7 +21,7 @@ import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotNull;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;

--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,8 @@
   </modules>
 
   <properties>
-    <raml-module-builder.version>35.0.6</raml-module-builder.version>
-    <vertx.version>4.3.7</vertx.version>
+    <raml-module-builder.version>35.2.0</raml-module-builder.version>
+    <vertx.version>4.5.4</vertx.version>
     <junit.version>4.13.2</junit.version>
     <mockito.version>5.1.1</mockito.version>
     <rest-assured.version>4.5.1</rest-assured.version>
@@ -28,8 +28,8 @@
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <sonar.exclusions>**/ModTenantAPI.java</sonar.exclusions>
-    <testcontainers.version>1.16.3</testcontainers.version>
-    <spring.version>5.3.23</spring.version>
+    <testcontainers.version>1.19.7</testcontainers.version>
+    <spring.version>5.3.32</spring.version>
   </properties>
 
   <dependencyManagement>
@@ -79,7 +79,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>versions-maven-plugin</artifactId>
-        <version>2.8.1</version>
+        <version>2.16.2</version>
         <configuration>
           <generateBackupPoms>false</generateBackupPoms>
         </configuration>
@@ -87,7 +87,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.2</version>
+        <version>3.2.5</version>
         <configuration>
           <useSystemClassLoader>false</useSystemClassLoader>
         </configuration>


### PR DESCRIPTION
## Purpose
Upgrade mod-di-converter-storage to RMB 35.2.0, Vertx 4.5.4

## Learning
[MODDICORE-398](https://folio-org.atlassian.net/browse/MODDICORE-398)
