### PR TITLE
MODINV-1004: Adjusting ecs sharing instance job profile

### DIFF
--- a/mod-di-converter-storage-server/src/main/resources/templates/db_scripts/manipulate_ecs_profile_wrappers.sql
+++ b/mod-di-converter-storage-server/src/main/resources/templates/db_scripts/manipulate_ecs_profile_wrappers.sql
@@ -1,0 +1,28 @@
+UPDATE ${myuniversity}_${mymodule}.action_to_mapping_profiles
+SET "jsonb"  = "jsonb"
+WHERE id = '654f9356-8a7f-49fc-b6d2-91b08df15433';
+
+UPDATE ${myuniversity}_${mymodule}.job_to_action_profiles
+SET "jsonb" = "jsonb"
+WHERE id = '7e1b00ad-eb12-4c27-aae7-3c4b39e97e3d';
+
+DELETE FROM ${myuniversity}_${mymodule}.profile_wrappers dpf
+WHERE dpf.id IN (
+SELECT pf.id
+FROM ${myuniversity}_${mymodule}.profile_wrappers pf
+    WHERE pf.profile_type IN
+    ('JOB_PROFILE','ACTION_PROFILE','MAPPING_PROFILE') AND
+    (pf.job_profile_id = '90fd4389-e5a9-4cc5-88cf-1568c0ff7e8b'
+    OR pf.action_profile_id = '671a848a-eb4e-49d2-9e01-41c179e789f5' OR pf.mapping_profile_id = 'f8d7e135-3c35-4c60-bb33-0a3cf01e7b94')
+    AND
+    NOT EXISTS (SELECT id, jsonb, creation_date, created_by, masterwrapperid, detailwrapperid
+	FROM ${myuniversity}_${mymodule}.job_to_action_profiles nested_jtap
+	WHERE pf.id = nested_jtap.masterwrapperid
+	OR
+	pf.id = nested_jtap.detailwrapperid)
+	AND NOT EXISTS (SELECT id, jsonb, creation_date, created_by, masterwrapperid, detailwrapperid
+	FROM ${myuniversity}_${mymodule}.action_to_mapping_profiles nested_atmp
+    WHERE pf.id = nested_atmp.masterwrapperid
+    OR
+    pf.id = nested_atmp.detailwrapperid)
+);

--- a/mod-di-converter-storage-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-di-converter-storage-server/src/main/resources/templates/db_scripts/schema.json
@@ -305,7 +305,7 @@
     },
     {
       "tableName": "metadata_internal",
-      "fromModuleVersion": "mod-di-converter-storage-2.2.0",
+      "fromModuleVersion": "mod-di-converter-storage-2.1.8",
       "withMetadata": true
     }
   ],

--- a/mod-di-converter-storage-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-di-converter-storage-server/src/main/resources/templates/db_scripts/schema.json
@@ -417,13 +417,13 @@
     },
     {
       "run": "after",
-      "snippetPath": "data-migration/set_account_no.sql",
-      "fromModuleVersion": "mod-di-converter-storage-2.2.0"
+      "snippetPath": "manipulate_ecs_profile_wrappers.sql",
+      "fromModuleVersion": "mod-di-converter-storage-2.1.9"
     },
     {
       "run": "after",
-      "snippetPath": "manipulate_ecs_profile_wrappers.sql",
-      "fromModuleVersion": "mod-di-converter-storage-2.3.0-SNAPSHOT"
+      "snippetPath": "data-migration/set_account_no.sql",
+      "fromModuleVersion": "mod-di-converter-storage-2.2.0"
     }
   ]
 }

--- a/mod-di-converter-storage-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-di-converter-storage-server/src/main/resources/templates/db_scripts/schema.json
@@ -417,13 +417,13 @@
     },
     {
       "run": "after",
-      "snippetPath": "manipulate_ecs_profile_wrappers.sql",
-      "fromModuleVersion": "mod-di-converter-storage-2.1.8"
+      "snippetPath": "data-migration/set_account_no.sql",
+      "fromModuleVersion": "mod-di-converter-storage-2.2.0"
     },
     {
       "run": "after",
-      "snippetPath": "data-migration/set_account_no.sql",
-      "fromModuleVersion": "mod-di-converter-storage-2.2.0"
+      "snippetPath": "manipulate_ecs_profile_wrappers.sql",
+      "fromModuleVersion": "mod-di-converter-storage-2.2.1"
     }
   ]
 }

--- a/mod-di-converter-storage-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-di-converter-storage-server/src/main/resources/templates/db_scripts/schema.json
@@ -305,7 +305,7 @@
     },
     {
       "tableName": "metadata_internal",
-      "fromModuleVersion": "mod-di-converter-storage-2.3.0-SNAPSHOT",
+      "fromModuleVersion": "mod-di-converter-storage-2.2.1",
       "withMetadata": true
     }
   ],

--- a/mod-di-converter-storage-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-di-converter-storage-server/src/main/resources/templates/db_scripts/schema.json
@@ -305,7 +305,7 @@
     },
     {
       "tableName": "metadata_internal",
-      "fromModuleVersion": "mod-di-converter-storage-2.2.1",
+      "fromModuleVersion": "mod-di-converter-storage-2.1.8",
       "withMetadata": true
     }
   ],
@@ -418,7 +418,7 @@
     {
       "run": "after",
       "snippetPath": "manipulate_ecs_profile_wrappers.sql",
-      "fromModuleVersion": "mod-di-converter-storage-2.1.9"
+      "fromModuleVersion": "mod-di-converter-storage-2.1.8"
     },
     {
       "run": "after",

--- a/mod-di-converter-storage-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-di-converter-storage-server/src/main/resources/templates/db_scripts/schema.json
@@ -419,6 +419,11 @@
       "run": "after",
       "snippetPath": "data-migration/set_account_no.sql",
       "fromModuleVersion": "mod-di-converter-storage-2.2.0"
+    },
+    {
+      "run": "after",
+      "snippetPath": "manipulate_ecs_profile_wrappers.sql",
+      "fromModuleVersion": "mod-di-converter-storage-2.3.0-SNAPSHOT"
     }
   ]
 }

--- a/mod-di-converter-storage-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-di-converter-storage-server/src/main/resources/templates/db_scripts/schema.json
@@ -305,7 +305,7 @@
     },
     {
       "tableName": "metadata_internal",
-      "fromModuleVersion": "mod-di-converter-storage-2.1.8",
+      "fromModuleVersion": "mod-di-converter-storage-2.2.0",
       "withMetadata": true
     }
   ],


### PR DESCRIPTION
## Purpose
After migration "ECS - Create instance and SRS MARC Bib" job profile does not work. It appears that there are duplicates of profile wrappers and missing data in job_to_action_profiles and action_to_mapping_profiles tables.
## Approach
Script to:
- update missing data for job_to_action_profiles and action_to_mapping_profiles;
- delete duplicate profile wrappers for job, action, mapping profiles;
- added changes to schema.json.

## Learning
[MODINV-1004](https://folio-org.atlassian.net/browse/MODINV-1004)