### PR TITLE
generate records for a profile

### DIFF
--- a/job-profile-wrangler/pom.xml
+++ b/job-profile-wrangler/pom.xml
@@ -20,6 +20,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.folio</groupId>
+      <artifactId>data-import-processing-core</artifactId>
+      <version>4.2.0</version>
+    </dependency>
+    <dependency>
       <groupId>org.jgrapht</groupId>
       <artifactId>jgrapht-core</artifactId>
       <version>1.5.2</version>
@@ -63,6 +68,22 @@
       <groupId>org.folio</groupId>
       <artifactId>mod-di-converter-storage-server</artifactId>
       <version>${project.parent.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <version>1.18.32</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.github.javafaker</groupId>
+      <artifactId>javafaker</artifactId>
+      <version>1.0.2</version>
+    </dependency>
+    <dependency>
+      <groupId>com.jayway.jsonpath</groupId>
+      <artifactId>json-path</artifactId>
+      <version>2.9.0</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/job-profile-wrangler/src/main/java/org/folio/graph/GraphConstruction.java
+++ b/job-profile-wrangler/src/main/java/org/folio/graph/GraphConstruction.java
@@ -1,0 +1,127 @@
+package org.folio.graph;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.folio.graph.edges.MatchRelationshipEdge;
+import org.folio.graph.edges.NonMatchRelationshipEdge;
+import org.folio.graph.edges.RegularEdge;
+import org.folio.graph.nodes.ActionProfileNode;
+import org.folio.graph.nodes.JobProfileNode;
+import org.folio.graph.nodes.MappingProfileNode;
+import org.folio.graph.nodes.MatchProfileNode;
+import org.folio.graph.nodes.Profile;
+import org.jgrapht.Graph;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class GraphConstruction {
+  private static final Logger LOGGER = LogManager.getLogger();
+
+  private Graph<Profile, RegularEdge> graph;
+  private JsonNode profileSnapshot;
+  private Map<Profile, JsonNode> profileContents = new HashMap<>();
+
+  public GraphConstruction(Graph<Profile, RegularEdge> graph, JsonNode profileSnapshot) {
+    this.graph = graph;
+    this.profileSnapshot = profileSnapshot;
+  }
+
+  public Graph<Profile, RegularEdge> getGraph() {
+    return graph;
+  }
+
+  public Map<Profile, JsonNode> getProfileContents() {
+    return Collections.unmodifiableMap(profileContents);
+  }
+
+  public Optional<Profile> construct() {
+    return constructInternal(graph, profileSnapshot);
+  }
+
+  public Optional<Profile> constructInternal(Graph<Profile, RegularEdge> graph, JsonNode profileSnapshot) {
+    String contentType = profileSnapshot.path("contentType").asText();
+
+    return switch (contentType) {
+      case "JOB_PROFILE" -> {
+        String dataType = profileSnapshot.path("content").path("dataType").asText();
+        String id = profileSnapshot.path("profileWrapperId").asText();
+        int order = profileSnapshot.path("order").asInt();
+        JobProfileNode node = new JobProfileNode(id, dataType, order);
+        graph.addVertex(node);
+        profileContents.put(node, profileSnapshot.path("content"));
+        addChildProfilesToGraph(graph, profileSnapshot, node);
+        yield Optional.of(node);
+      }
+      case "MATCH_PROFILE" -> {
+        String incomingRecordType = profileSnapshot.path("content").path("incomingRecordType").asText();
+        String existingRecordType = profileSnapshot.path("content").path("existingRecordType").asText();
+        String id = profileSnapshot.path("profileWrapperId").asText();
+        int order = profileSnapshot.path("order").asInt();
+        MatchProfileNode node = new MatchProfileNode(id, incomingRecordType, existingRecordType, order);
+        graph.addVertex(node);
+        profileContents.put(node, profileSnapshot.path("content"));
+        addChildMatchProfilesToGraph(graph, profileSnapshot, node);
+        yield Optional.of(node);
+      }
+      case "ACTION_PROFILE" -> {
+        String folioRecord = profileSnapshot.path("content").path("folioRecord").asText();
+        String actionType = profileSnapshot.path("content").path("action").asText();
+        String id = profileSnapshot.path("profileWrapperId").asText();
+        int order = profileSnapshot.path("order").asInt();
+        ActionProfileNode node = new ActionProfileNode(id, actionType, folioRecord, order);
+        graph.addVertex(node);
+        profileContents.put(node, profileSnapshot.path("content"));
+        addChildProfilesToGraph(graph, profileSnapshot, node);
+        yield Optional.of(node);
+      }
+      case "MAPPING_PROFILE" -> {
+        String incomingRecordType = profileSnapshot.path("content").path("incomingRecordType").asText();
+        String existingRecordType = profileSnapshot.path("content").path("existingRecordType").asText();
+        String id = profileSnapshot.path("profileWrapperId").asText();
+        int order = profileSnapshot.path("order").asInt();
+        MappingProfileNode node = new MappingProfileNode(id, incomingRecordType, existingRecordType, order);
+        graph.addVertex(node);
+        profileContents.put(node, profileSnapshot.path("content"));
+        JsonNode childSnapshotWrappers = profileSnapshot.get("childSnapshotWrappers");
+        if (childSnapshotWrappers != null && childSnapshotWrappers.isArray() && !childSnapshotWrappers.isEmpty()) {
+          LOGGER.warn("Found {} childSnapshotWrappers for mapping profile: {}", childSnapshotWrappers.size(), node);
+        }
+        yield Optional.of(node);
+      }
+      default -> Optional.empty();
+    };
+  }
+
+  private void addChildProfilesToGraph(Graph<Profile, RegularEdge> graph, JsonNode profileSnapshot, Profile node) {
+    JsonNode childSnapshotWrappers = profileSnapshot.get("childSnapshotWrappers");
+    if (childSnapshotWrappers != null && childSnapshotWrappers.isArray()) {
+      for (JsonNode childSnapshotWrapper : childSnapshotWrappers) {
+        Optional<Profile> profile = constructInternal(graph, childSnapshotWrapper);
+        profile.ifPresent(value -> graph.addEdge(node, value));
+      }
+    }
+  }
+
+  private void addChildMatchProfilesToGraph(Graph<Profile, RegularEdge> graph, JsonNode profileSnapshot, MatchProfileNode node) {
+    JsonNode childSnapshotWrappers = profileSnapshot.get("childSnapshotWrappers");
+    if (childSnapshotWrappers != null && childSnapshotWrappers.isArray()) {
+      for (JsonNode childSnapshotWrapper : childSnapshotWrappers) {
+        Optional<Profile> profile = constructInternal(graph, childSnapshotWrapper);
+        profile.ifPresent(value -> {
+          String reactTo = childSnapshotWrapper.path("reactTo").asText();
+          if ("NON_MATCH".equals(reactTo)) {
+            graph.addEdge(node, value, new NonMatchRelationshipEdge());
+          } else if ("MATCH".equals(reactTo)) {
+            graph.addEdge(node, value, new MatchRelationshipEdge());
+          } else {
+            LOGGER.warn("Found invalid relationship for matching on match profile: {}", node);
+          }
+        });
+      }
+    }
+  }
+}

--- a/job-profile-wrangler/src/main/java/org/folio/recordgen/MARC008Generator.java
+++ b/job-profile-wrangler/src/main/java/org/folio/recordgen/MARC008Generator.java
@@ -1,0 +1,46 @@
+package org.folio.recordgen;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Random;
+
+public class MARC008Generator {
+  private static final String MATERIAL_TYPES = "abcdefghijklmnopqrstuvwxyz";
+  private static final String LANGUAGES = "abcdefghijklmnopqrstuvwxyz";
+  private static final String COUNTRIES = "abcdefghijklmnopqrstuvwxyz";
+
+  private static String generateRandomMARCDate() {
+    LocalDate randomDate = LocalDate.now().minusDays(new Random().nextInt(365 * 50));
+    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyMMdd");
+    return randomDate.format(formatter);
+  }
+
+  private static String generateRandomDateType() {
+    String[] dateTypes = {"s", "c", "d", "e", "m", "n", "u"};
+    return dateTypes[new Random().nextInt(dateTypes.length)];
+  }
+
+  private static String generateRandomYear() {
+    int year = 1500 + new Random().nextInt(524); // Generates years between 1500 and 2023
+    return String.format("%04d", year);
+  }
+
+  private static char generateRandomCode(String codes) {
+    return codes.charAt(new Random().nextInt(codes.length()));
+  }
+
+  public static String generateRandom008() {
+    StringBuilder marc008 = new StringBuilder();
+    marc008.append(generateRandomMARCDate()); // 6 characters for date
+    marc008.append(generateRandomDateType()); // 1 character for date type
+    marc008.append(generateRandomYear()); // 4 characters for date 1
+    marc008.append(generateRandomYear()); // 4 characters for date 2
+    marc008.append(generateRandomCode(COUNTRIES)); // 3 characters for country
+    marc008.append(generateRandomCode(LANGUAGES)); // 1 character for language
+    marc008.append(generateRandomCode(MATERIAL_TYPES)); // 1 character for material type
+    marc008.append(" 0 a0"); // 5 fixed characters
+    marc008.append(generateRandomCode(LANGUAGES)); // 3 characters for language of cataloging
+    marc008.append(generateRandomCode("abcdefghi")); // 1 character for successive/latest entry
+    return marc008.toString();
+  }
+}

--- a/job-profile-wrangler/src/main/java/org/folio/recordgen/MatchDetailResolver.java
+++ b/job-profile-wrangler/src/main/java/org/folio/recordgen/MatchDetailResolver.java
@@ -1,0 +1,118 @@
+package org.folio.recordgen;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.folio.processing.value.DateValue;
+import org.folio.processing.value.MissingValue;
+import org.folio.processing.value.StringValue;
+import org.folio.processing.value.Value;
+import org.folio.rest.jaxrs.model.Field;
+import org.folio.rest.jaxrs.model.MarcField;
+import org.folio.rest.jaxrs.model.MarcSubfield;
+import org.folio.rest.jaxrs.model.MatchDetail;
+import org.folio.rest.jaxrs.model.MatchExpression;
+import org.folio.rest.jaxrs.model.StaticValueDetails;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Objects.nonNull;
+import static org.folio.rest.jaxrs.model.MatchExpression.DataValueType.STATIC_VALUE;
+import static org.folio.rest.jaxrs.model.MatchExpression.DataValueType.VALUE_FROM_RECORD;
+
+/**
+ * Resolves match details based on incoming and existing match expressions.
+ * TODO: consider match criterion
+ */
+public class MatchDetailResolver {
+
+    public static final String FIELD_PROFILE_LABEL = "field";
+    public static final String IND_1_PROFILE_LABEL = "indicator1";
+    public static final String IND_2_PROFILE_LABEL = "indicator2";
+    public static final String SUBFIELD_PROFILE_LABEL = "recordSubfield";
+
+    /**
+     * Resolves a match detail based on the incoming and existing match expressions.
+     *
+     * @param matchDetail The match detail to resolve.
+     * @param isNonMatch  Indicates whether it is a non-match.
+     * @return The resolved match.
+     */
+    public ResolvedMatch resolve(MatchDetail matchDetail, boolean isNonMatch) {
+        MatchExpression incomingMatchExpression = matchDetail.getIncomingMatchExpression();
+        MatchExpression existingMatchExpression = matchDetail.getExistingMatchExpression();
+        var incomingPair = resolveMatch(incomingMatchExpression);
+        var existingPair = resolveMatch(existingMatchExpression);
+        ResolvedMatch.ResolvedMatchBuilder builder = ResolvedMatch.builder();
+        incomingPair.ifPresent(pair ->
+                builder
+                        .incomingDataValueType(pair.getKey())
+                        .incoming(pair.getValue()));
+        existingPair.ifPresent(pair ->
+                builder
+                        .existingDataValueType(pair.getKey())
+                        .existing(pair.getValue()));
+        builder.isNonMatch(isNonMatch);
+        return builder.build();
+    }
+
+    /**
+     * Resolves a match expression.
+     *
+     * @param matchExpression The match expression to resolve.
+     * @return An optional pair containing the data value type and the resolved value.
+     */
+    private Optional<Pair<MatchExpression.DataValueType, Object>> resolveMatch(MatchExpression matchExpression) {
+        if (matchExpression.getDataValueType() == STATIC_VALUE && nonNull(matchExpression.getStaticValueDetails())) {
+            StaticValueDetails staticValueDetails = matchExpression.getStaticValueDetails();
+            return Optional.of(Pair.of(STATIC_VALUE, switch (staticValueDetails.getStaticValueType()) {
+                case TEXT -> obtainStringValue(staticValueDetails.getText());
+                case NUMBER -> obtainStringValue(staticValueDetails.getNumber());
+                case EXACT_DATE ->
+                        obtainDateValue(staticValueDetails.getExactDate(), staticValueDetails.getExactDate());
+                case DATE_RANGE -> obtainDateValue(staticValueDetails.getFromDate(), staticValueDetails.getToDate());
+            }));
+        } else if (matchExpression.getDataValueType() == VALUE_FROM_RECORD) {
+            List<Field> fields = matchExpression.getFields();
+            if (fields.size() == 1) {
+                return Optional.of(Pair.of(VALUE_FROM_RECORD, fields.get(0)));
+            }
+            MarcField marcField = fields.stream()
+                    .reduce(new MarcField(), (result, field) -> {
+                        if (FIELD_PROFILE_LABEL.equals(field.getLabel())) {
+                            result = result.withField(field.getValue());
+                        } else if (IND_1_PROFILE_LABEL.equals(field.getLabel())) {
+                            result = result.withIndicator1(field.getValue());
+                        } else if (IND_2_PROFILE_LABEL.equals(field.getLabel())) {
+                            result = result.withIndicator2(field.getValue());
+                        } else if (SUBFIELD_PROFILE_LABEL.equals(field.getLabel())) {
+                            result = result.withSubfields(List.of(new MarcSubfield().withSubfield(field.getValue())));
+                        }
+                        return result;
+                    }, (result1, result2) -> result1);
+            return Optional.of(Pair.of(VALUE_FROM_RECORD, marcField));
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Obtains a string value from the given input.
+     *
+     * @param value The input value.
+     * @return The string value or a missing value if the input is null.
+     */
+    private Value obtainStringValue(String value) {
+        return nonNull(value) ? StringValue.of(value) : MissingValue.getInstance();
+    }
+
+    /**
+     * Obtains a date value from the given from and to dates.
+     *
+     * @param from The from date.
+     * @param to   The to date.
+     * @return The date value or a missing value if either from or to date is null.
+     */
+    private Value obtainDateValue(Date from, Date to) {
+        return nonNull(from) && nonNull(to) ? DateValue.of(from, to) : MissingValue.getInstance();
+    }
+}

--- a/job-profile-wrangler/src/main/java/org/folio/recordgen/RecordGenerator.java
+++ b/job-profile-wrangler/src/main/java/org/folio/recordgen/RecordGenerator.java
@@ -1,0 +1,438 @@
+package org.folio.recordgen;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.MissingNode;
+import com.github.javafaker.Faker;
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.spi.json.JacksonJsonNodeJsonProvider;
+import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
+import org.apache.commons.lang3.CharUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.folio.graph.GraphConstruction;
+import org.folio.graph.edges.MatchRelationshipEdge;
+import org.folio.graph.edges.NonMatchRelationshipEdge;
+import org.folio.graph.edges.RegularEdge;
+import org.folio.graph.nodes.ActionProfileNode;
+import org.folio.graph.nodes.MappingProfileNode;
+import org.folio.graph.nodes.MatchProfileNode;
+import org.folio.graph.nodes.Profile;
+import org.folio.http.FolioClient;
+import org.folio.rest.jaxrs.model.Field;
+import org.folio.rest.jaxrs.model.MarcField;
+import org.folio.rest.jaxrs.model.MarcSubfield;
+import org.folio.rest.jaxrs.model.MatchDetail;
+import org.folio.rest.jaxrs.model.MatchExpression;
+import org.folio.rest.jaxrs.model.MatchProfile;
+import org.jgrapht.Graph;
+import org.jgrapht.GraphPath;
+import org.jgrapht.alg.shortestpath.AllDirectedPaths;
+import org.jgrapht.graph.SimpleDirectedGraph;
+import org.marc4j.MarcPermissiveStreamReader;
+import org.marc4j.MarcReader;
+import org.marc4j.MarcReaderFactory;
+import org.marc4j.marc.DataField;
+import org.marc4j.marc.MarcFactory;
+import org.marc4j.marc.Record;
+import org.marc4j.marc.VariableField;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import static com.jayway.jsonpath.JsonPath.using;
+import static org.folio.Constants.OBJECT_MAPPER;
+
+/**
+ * Generates records based on a job profile.
+ */
+public class RecordGenerator {
+  private static final Logger LOGGER = LogManager.getLogger();
+  private static final String JSON_PATH_SEPARATOR = ".";
+  private static final MarcFactory MARC_FACTORY = MarcFactory.newInstance();
+  private static final Faker FAKER = new Faker();
+  private static final Configuration JACKSON_JSON_NODE_CONFIGURATION = Configuration
+    .builder()
+    .mappingProvider(new JacksonMappingProvider())
+    .jsonProvider(new JacksonJsonNodeJsonProvider())
+    .build();
+  private final FolioClient client;
+  private final RoundRobinIdentifiers identifiers;
+
+  public RecordGenerator(FolioClient client, RoundRobinIdentifiers identifiers) {
+    this.client = client;
+    this.identifiers = identifiers;
+  }
+
+  /**
+   * Generates records based on the given job profile ID.
+   *
+   * @param jobProfileId The ID of the job profile.
+   * @return An Optional containing the generated records as a byte array, or an empty Optional if generation fails.
+   * @throws IOException If an I/O error occurs.
+   */
+  public Optional<Collection<Record>> generate(String jobProfileId) throws IOException {
+    Optional<JsonNode> jobProfileSnapshot = client.getJobProfileSnapshot(jobProfileId);
+    if (jobProfileSnapshot.isEmpty()) return Optional.empty();
+    Graph<Profile, RegularEdge> profileGraph = new SimpleDirectedGraph<>(RegularEdge.class);
+    GraphConstruction graphConstruction = new GraphConstruction(profileGraph, jobProfileSnapshot.get());
+    Optional<Profile> jobProfileOptional = graphConstruction.construct();
+    Map<Profile, JsonNode> profileContents = graphConstruction.getProfileContents();
+    if (jobProfileOptional.isEmpty()) return Optional.empty();
+
+    List<GraphPath<Profile, RegularEdge>> paths = findAllPathsToLeafNodes(profileGraph, jobProfileOptional.get());
+
+    // resolve matches for paths
+    Map<GraphPath<Profile, RegularEdge>, List<ResolvedMatch>> resolvedMatchesByPath = new HashMap<>();
+    for (GraphPath<Profile, RegularEdge> path : paths) {
+      resolvedMatchesByPath.put(path, resolveMatches(profileContents, path));
+    }
+
+    List<Record> records = new ArrayList<>();
+    for (var resolvedMatches : resolvedMatchesByPath.entrySet()) {
+      var optionalRecord = generateRecord(resolvedMatches.getKey(), resolvedMatches.getValue());
+      optionalRecord.ifPresent(records::add);
+      identifiers.next();
+    }
+
+    return Optional.of(records);
+  }
+
+
+  private Optional<Record> generateRecord(GraphPath<Profile, RegularEdge> path, List<ResolvedMatch> resolvedMatches) {
+    Profile endVertex = path.getEndVertex();
+    if (!(endVertex instanceof ActionProfileNode)) return Optional.empty();
+    String recordType = ((ActionProfileNode) endVertex).folioRecord();
+    Record record = MARC_FACTORY.newRecord();
+    if (Arrays.stream(FolioClient.ExportRecordType.values()).anyMatch(type -> type.name().equals(recordType))) {
+      FolioClient.ExportRecordType exportRecordType = FolioClient.ExportRecordType.valueOf(recordType);
+      if (!FolioClient.ExportRecordType.ITEM.equals(exportRecordType)) { // no default data export profile exists for items
+        Optional<byte[]> bytes = client.exportFolioObject(exportRecordType, identifiers.get().forRecordType(exportRecordType));
+        if (bytes.isPresent()) {
+          MarcReader reader = new MarcPermissiveStreamReader(new ByteArrayInputStream(bytes.get()), true, true);
+          record = reader.next();
+        }
+      }
+    }
+
+    for (var resolvedMatch : resolvedMatches) {
+      if (MatchExpression.DataValueType.VALUE_FROM_RECORD.equals(resolvedMatch.getIncomingDataValueType()) &&
+        resolvedMatch.getIncoming() instanceof MarcField incomingMarcField) {
+        if (incomingMarcField.getSubfields().size() > 1) {
+          LOGGER.error("More than one subfield is present in record. field={}", incomingMarcField);
+          return Optional.empty();
+        }
+
+        DataField df = MARC_FACTORY.newDataField(incomingMarcField.getField(),
+          CharUtils.toChar(incomingMarcField.getIndicator1(), ' '),
+          CharUtils.toChar(incomingMarcField.getIndicator2(), ' '));
+        Object existing = resolvedMatch.getExisting();
+        JsonNode loadedValueJsonNode = getExistingValue(existing);
+
+        if (!loadedValueJsonNode.isArray()) {
+          // convert single nodes to array so that it is suitable for upcoming logic
+          loadedValueJsonNode = OBJECT_MAPPER.createArrayNode().add(loadedValueJsonNode);
+        }
+
+        for (var node : loadedValueJsonNode) {
+          char subfieldTag = CharUtils.toChar(incomingMarcField
+            .getSubfields()
+            .get(0)
+            .getSubfield(), ' ');
+          if (!resolvedMatch.isNonMatch()) {
+            df.addSubfield(MARC_FACTORY.newSubfield(subfieldTag, node.asText()));
+          } else {
+            Optional<Instant> date = isDate(node.asText());
+            if (date.isEmpty()) {
+              df.addSubfield(MARC_FACTORY.newSubfield(subfieldTag, "~" + node.asText()));
+            } else {
+              df.addSubfield(MARC_FACTORY.newSubfield(subfieldTag, date.get().plusSeconds(60).toString()));
+            }
+          }
+        }
+
+        record.addVariableField(df);
+      } else if (MatchExpression.DataValueType.STATIC_VALUE.equals(resolvedMatch.getIncomingDataValueType())) {
+        if (resolvedMatch.getExisting() instanceof MarcField existingMarcField) {
+          Object existing = resolvedMatch.getExisting();
+          JsonNode loadedValueJsonNode = getExistingValue(existing);
+          DataField df = MARC_FACTORY.newDataField(existingMarcField.getField(),
+            CharUtils.toChar(existingMarcField.getIndicator1(), ' '),
+            CharUtils.toChar(existingMarcField.getIndicator2(), ' '));
+          char subfieldTag = CharUtils.toChar(existingMarcField
+            .getSubfields()
+            .get(0)
+            .getSubfield(), ' ');
+          if (!resolvedMatch.isNonMatch()) {
+            df.addSubfield(MARC_FACTORY.newSubfield(subfieldTag, loadedValueJsonNode.asText()));
+          } else {
+            df.addSubfield(MARC_FACTORY.newSubfield(subfieldTag, "~" + loadedValueJsonNode.asText()));
+          }
+          record.addVariableField(df);
+        }
+      }
+    }
+
+    addVariableFieldConditionally(record, "245",
+      () -> MARC_FACTORY.newDataField("245", ' ', ' '),
+      dataField -> {
+        if (dataField.getSubfields('a') == null) {
+          dataField.addSubfield(MARC_FACTORY.newSubfield('a', FAKER.book().title()));
+        }
+      });
+
+    addVariableFieldConditionally(record, "008",
+      () -> MARC_FACTORY.newControlField("008", MARC008Generator.generateRandom008()),
+      field -> {
+      });
+
+    addVariableFieldConditionally(record, "856",
+      () -> MARC_FACTORY.newDataField("856", '4', '0'),
+      dataField -> {
+        if (dataField.getSubfields('u') == null) {
+          dataField.addSubfield(MARC_FACTORY.newSubfield('u', FAKER.internet().url()));
+        }
+      });
+
+    return Optional.of(record);
+  }
+
+  /**
+   * Resolves the matches for a given path in the profile graph.
+   *
+   * @param profileContents The map containing the profile contents, where the keys are the profiles and the values are the corresponding JSON nodes.
+   * @param path            The graph path representing the sequence of profiles and edges to resolve matches for.
+   * @return A list of resolved matches based on the profiles and edges in the given path.
+   * @throws JsonProcessingException If an error occurs while processing the JSON content of a match profile.
+   */
+  private List<ResolvedMatch> resolveMatches(Map<Profile, JsonNode> profileContents,
+                                             GraphPath<Profile, RegularEdge> path) throws JsonProcessingException {
+    List<ResolvedMatch> resolvedMatches = new ArrayList<>();
+    for (var edge : path.getEdgeList()) {
+      Profile vertex = (Profile) edge.getSource();
+      if (vertex instanceof MatchProfileNode matchp) {
+        boolean isNonMatch = edge instanceof NonMatchRelationshipEdge;
+
+        JsonNode jsonNode = profileContents.get(matchp);
+        MatchProfile matchProfile = OBJECT_MAPPER.treeToValue(jsonNode, MatchProfile.class);
+        MatchDetail matchDetail = matchProfile.getMatchDetails().get(0); // only one match detail is expected for now
+        MatchDetailResolver matchDetailResolver = new MatchDetailResolver();
+        resolvedMatches.add(matchDetailResolver.resolve(matchDetail, isNonMatch));
+      }
+    }
+    return resolvedMatches;
+  }
+
+  /**
+   * Finds all paths from the given job profile to the leaf nodes in the graph.
+   *
+   * <p>This method uses the {@link AllDirectedPaths} algorithm to find all paths from the job profile
+   * to the leaf nodes in the graph. A leaf node is defined as a node with no outgoing edges.
+   * The method considers different types of profiles (mapping profiles, action profiles, match profiles)
+   * and their respective owning profiles (parent profiles) while determining the leaf nodes.
+   *
+   * <p>For match profiles, the method includes both the match and non-match profiles linked to the match
+   * profile as leaf nodes.
+   *
+   * @param graph      the graph representing the profiles and their relationships
+   * @param jobProfile the starting job profile for finding the paths
+   * @return a list of {@link GraphPath} objects representing all paths from the job profile to the leaf nodes
+   */
+  private List<GraphPath<Profile, RegularEdge>> findAllPathsToLeafNodes(Graph<Profile, RegularEdge> graph, Profile jobProfile) {
+    AllDirectedPaths<Profile, RegularEdge> pathFinder = new AllDirectedPaths<>(graph);
+
+    // Find all leaf nodes
+    Set<Profile> allLeafNodes = graph.vertexSet().stream()
+      .filter(v -> graph.outDegreeOf(v) == 0)
+      .map(node -> {
+        // convert mapping profile to their owning action profiles
+        if (node instanceof MappingProfileNode) {
+          return getParent(graph, node);
+        }
+        return node;
+      })
+      .map(node -> {
+        // convert action profiles to their owning job/match profiles
+        if (node instanceof ActionProfileNode) {
+          return getParent(graph, node);
+        }
+        return node;
+      })
+      .map(node -> {
+        // get one profile linked by MATCH and another by NON_MATCH for match profiles
+        if (node instanceof MatchProfileNode matchProfileNode) {
+          Set<RegularEdge> regularEdges = graph.outgoingEdgesOf(matchProfileNode);
+          boolean hasMatch = false;
+          boolean hasNonMatch = false;
+          List<Profile> result = new ArrayList<>();
+          for (RegularEdge regularEdge : regularEdges) {
+            if (!hasNonMatch && regularEdge instanceof NonMatchRelationshipEdge) {
+              hasNonMatch = true;
+              result.add(graph.getEdgeTarget(regularEdge));
+            }
+            if (!hasMatch && regularEdge instanceof MatchRelationshipEdge) {
+              hasMatch = true;
+              result.add(graph.getEdgeTarget(regularEdge));
+            }
+          }
+          if (!hasMatch && !hasNonMatch) return List.of(node);
+          return result;
+        }
+        // return other non-match profiles as is
+        return List.of(node);
+      })
+      .flatMap(Collection::stream)
+      .collect(Collectors.toSet());
+
+    return pathFinder.getAllPaths(Set.of(jobProfile), allLeafNodes, true, null);
+  }
+
+  private static Profile getParent(Graph<Profile, RegularEdge> graph, Profile vertex) {
+    return graph.incomingEdgesOf(vertex).stream()
+      .map(graph::getEdgeSource)
+      .findFirst()
+      .orElse(null);
+  }
+
+  private JsonNode getExistingValue(Object existing) {
+    JsonNode loadedValueJsonNode = null;
+    if (existing instanceof Field existingField) {
+      String objectType = StringUtils.substringBefore(existingField.getValue(), JSON_PATH_SEPARATOR);
+      String path = StringUtils.substringAfter(existingField.getValue(), JSON_PATH_SEPARATOR);
+      loadedValueJsonNode = loadValue(objectType, path);
+    } else if (existing instanceof MarcField existingMarcField) {
+      loadedValueJsonNode = loadMarcValue(existingMarcField);
+    }
+    return loadedValueJsonNode;
+  }
+
+  /**
+   * Conditionally adds a variable field to a MARC record.
+   *
+   * <p>If the specified variable field with the given tag does not exist in the record,
+   * a new variable field is created using the provided {@code createVariableField} supplier
+   * and added to the record. The {@code configureVariableField} consumer is then applied to
+   * the variable field, allowing for further configuration such as adding subfields.
+   *
+   * <p>If the specified variable field already exists in the record, the
+   * {@code configureVariableField} consumer is applied directly to the existing variable field.
+   *
+   * @param <T>                    the type of the variable field, which must extend {@link VariableField}
+   * @param record                 the MARC record to which the variable field will be added
+   * @param tag                    the tag identifying the variable field
+   * @param createVariableField    a supplier function that creates a new instance of the variable field
+   * @param configureVariableField a consumer function that configures the variable field, such as adding subfields
+   */
+  private <T extends VariableField> void addVariableFieldConditionally(Record record, String tag,
+                                                                       Supplier<T> createVariableField,
+                                                                       Consumer<T> configureVariableField) {
+    T variableField = (T) record.getVariableField(tag);
+    if (variableField == null) {
+      variableField = createVariableField.get();
+      record.addVariableField(variableField);
+    }
+    configureVariableField.accept(variableField);
+  }
+
+  /**
+   * Loads a value from the specified object type and JSON path.
+   *
+   * @param objectType The type of the object.
+   * @param jsonPath   The JSON path to the value.
+   * @return The loaded value as a JsonNode.
+   * @throws RuntimeException If the value cannot be loaded.
+   */
+  private JsonNode loadValue(String objectType, String jsonPath) {
+    Optional<JsonNode> result = Optional.empty();
+    switch (objectType) {
+      case "instance" -> {
+        result = client.getInstance(identifiers.get().instanceId());
+      }
+      case "holdingsrecord" -> {
+        result = client.getHoldings(identifiers.get().holdingsId());
+      }
+      case "item" -> {
+        result = client.getItem(identifiers.get().itemId());
+      }
+      case "sourcerecord" -> {
+        result = client.getSourceRecordBySRSId(identifiers.get().sourceRecordId());
+      }
+    }
+    if (result.isEmpty()) {
+      LOGGER.error("could not find record for {}", objectType);
+      return MissingNode.getInstance();
+    }
+
+    // the normalization occurs because follow using CQL which is close to JsonPath but not exactly.
+    String normalizedJsonPath = jsonPath.replace("[]", "[*]");
+    return using(JACKSON_JSON_NODE_CONFIGURATION)
+      .parse(result.get())
+      .read(normalizedJsonPath);
+
+  }
+
+  private JsonNode loadMarcValue(MarcField marcField) {
+    JsonNode fieldsArray = loadValue("sourcerecord", "parsedRecord.content.fields");
+    if (!(fieldsArray instanceof ArrayNode arrayNode)) {
+      LOGGER.error("Something was wrong when getting MARC fields. It wasn't an array. json={}", fieldsArray);
+      return MissingNode.getInstance();
+    }
+
+    for (JsonNode fieldNode : arrayNode) {
+      JsonNode foundFieldNode = fieldNode.get(marcField.getField());
+      if (foundFieldNode == null) continue;
+
+      JsonNode ind1Node = foundFieldNode.path("ind1");
+      JsonNode ind2Node = foundFieldNode.path("ind2");
+
+      if (!ind1Node.asText().equals(marcField.getIndicator1()) ||
+        !ind2Node.asText().equals(marcField.getIndicator2())) {
+        continue;
+      }
+
+      JsonNode subfieldsNode = foundFieldNode.path("subfields");
+      if (subfieldsNode.isArray()) {
+        Optional<MarcSubfield> first = marcField.getSubfields().stream().findFirst(); // there should be only one subfield
+        if (first.isEmpty()) continue;
+        for (JsonNode subfieldNode : subfieldsNode) {
+          JsonNode valueNode = subfieldNode.path(first.get().getSubfield());
+          if (valueNode != null) {
+            return valueNode;
+          }
+        }
+      }
+      break;
+    }
+    return MissingNode.getInstance();
+  }
+
+  /**
+   * Checks if the given string represents a date.
+   *
+   * @param dateString The string to check.
+   * @return An Optional containing the parsed Instant if the string is a valid date, or an empty Optional otherwise.
+   */
+  private static Optional<Instant> isDate(String dateString) {
+    try {
+      return Optional.of(Instant.parse(dateString));
+    } catch (DateTimeParseException e) {
+      return Optional.empty();
+    }
+  }
+
+}

--- a/job-profile-wrangler/src/main/java/org/folio/recordgen/ResolvedMatch.java
+++ b/job-profile-wrangler/src/main/java/org/folio/recordgen/ResolvedMatch.java
@@ -1,0 +1,18 @@
+package org.folio.recordgen;
+
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import org.folio.rest.jaxrs.model.MatchExpression;
+
+
+@Builder
+@Getter
+@EqualsAndHashCode
+public class ResolvedMatch {
+  private Object incoming;
+  private MatchExpression.DataValueType incomingDataValueType;
+  private Object existing;
+  private MatchExpression.DataValueType existingDataValueType;
+  private boolean isNonMatch;
+}

--- a/job-profile-wrangler/src/main/java/org/folio/recordgen/RoundRobinIdentifier.java
+++ b/job-profile-wrangler/src/main/java/org/folio/recordgen/RoundRobinIdentifier.java
@@ -1,0 +1,19 @@
+package org.folio.recordgen;
+
+
+import lombok.Builder;
+import org.folio.http.FolioClient;
+
+@Builder
+public record RoundRobinIdentifier(String instanceId, String holdingsId, String itemId, String authorityId,
+                                   String sourceRecordId) {
+
+  public String forRecordType(FolioClient.ExportRecordType recordType){
+    return switch (recordType){
+      case INSTANCE -> instanceId;
+      case HOLDINGS -> holdingsId;
+      case ITEM -> itemId;
+      case AUTHORITY -> authorityId;
+    };
+  }
+}

--- a/job-profile-wrangler/src/main/java/org/folio/recordgen/RoundRobinIdentifiers.java
+++ b/job-profile-wrangler/src/main/java/org/folio/recordgen/RoundRobinIdentifiers.java
@@ -1,0 +1,31 @@
+package org.folio.recordgen;
+
+import java.util.LinkedList;
+import java.util.Queue;
+
+public class RoundRobinIdentifiers {
+  private Queue<RoundRobinIdentifier> queue;
+
+  public RoundRobinIdentifiers(Iterable<RoundRobinIdentifier> items) {
+    queue = new LinkedList<>();
+    for (RoundRobinIdentifier item : items) {
+      queue.offer(item);
+    }
+  }
+
+  public RoundRobinIdentifier get() {
+    if (queue.isEmpty()) {
+      return null;
+    }
+    return queue.peek();
+  }
+
+  public RoundRobinIdentifier next() {
+    if (queue.isEmpty()) {
+      return null;
+    }
+    RoundRobinIdentifier item = queue.poll();
+    queue.offer(item);
+    return queue.peek();
+  }
+}

--- a/job-profile-wrangler/src/test/java/org/folio/recordgen/RecordGeneratorTest.java
+++ b/job-profile-wrangler/src/test/java/org/folio/recordgen/RecordGeneratorTest.java
@@ -1,0 +1,94 @@
+package org.folio.recordgen;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.io.Resources;
+import org.folio.http.FolioClient;
+import org.junit.Before;
+import org.junit.Test;
+import org.marc4j.marc.ControlField;
+import org.marc4j.marc.DataField;
+import org.marc4j.marc.Record;
+import org.marc4j.marc.Subfield;
+import org.marc4j.marc.VariableField;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.folio.Constants.OBJECT_MAPPER;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.when;
+
+public class RecordGeneratorTest {
+
+  @Mock
+  private FolioClient client;
+
+  @Mock
+  private RoundRobinIdentifiers roundRobinIdentifiers;
+
+
+  private RecordGenerator recordGenerator;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.openMocks(this);
+    recordGenerator = new RecordGenerator(client, roundRobinIdentifiers);
+  }
+
+  @Test
+  public void testGenerateWithEmptyJobProfileSnapshot() throws IOException {
+    when(client.getJobProfileSnapshot(anyString())).thenReturn(Optional.empty());
+
+    Optional<Collection<Record>> result = recordGenerator.generate("jobProfileId");
+
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  public void testGenerateWithJobProfileSnapshot() throws IOException {
+    final RoundRobinIdentifier roundRobinIdentifier = RoundRobinIdentifier.builder()
+      .instanceId(UUID.randomUUID().toString())
+      .holdingsId(UUID.randomUUID().toString())
+      .itemId(UUID.randomUUID().toString())
+      .authorityId(UUID.randomUUID().toString())
+      .sourceRecordId(UUID.randomUUID().toString())
+      .build();
+    String snapshot = Resources.toString(Resources.getResource("record_gen_job_profile_snapshot.json"), StandardCharsets.UTF_8);
+    JsonNode jobProfileSnapshot = OBJECT_MAPPER.readTree(snapshot);
+    String instanceString = Resources.toString(Resources.getResource("instance_response.json"), StandardCharsets.UTF_8);
+    JsonNode instanceJson = OBJECT_MAPPER.readTree(instanceString);
+    String holdingsString = Resources.toString(Resources.getResource("holdings_response.json"), StandardCharsets.UTF_8);
+    JsonNode holdingsJson = OBJECT_MAPPER.readTree(holdingsString);
+    String sourceRecordString = Resources.toString(Resources.getResource("source_record_response.json"), StandardCharsets.UTF_8);
+    JsonNode sourceRecordJson = OBJECT_MAPPER.readTree(sourceRecordString);
+
+    when(roundRobinIdentifiers.get()).thenReturn(roundRobinIdentifier);
+    when(client.getJobProfileSnapshot(anyString())).thenReturn(Optional.of(jobProfileSnapshot));
+    when(client.getInstance(anyString())).thenReturn(Optional.of(instanceJson));
+    when(client.getHoldings(anyString())).thenReturn(Optional.of(holdingsJson));
+    when(client.getSourceRecordBySRSId(anyString())).thenReturn(Optional.of(sourceRecordJson));
+
+    Optional<Collection<Record>> result = recordGenerator.generate("jobProfileId");
+
+    assertNotNull(result);
+    assertTrue(result.isPresent());
+    Collection<Record> records = result.get();
+    assertEquals(3, records.size());
+    Record record = records.iterator().next();
+
+    VariableField variableField008 = record.getVariableField("008");
+    assertNotNull(variableField008);
+    assertTrue(variableField008 instanceof ControlField);
+    ControlField controlField008 = (ControlField) variableField008;
+    assertNotNull(controlField008);
+    assertNotNull(controlField008.getData());
+  }
+}

--- a/job-profile-wrangler/src/test/java/org/folio/recordgen/RoundRobinIdentifiersTest.java
+++ b/job-profile-wrangler/src/test/java/org/folio/recordgen/RoundRobinIdentifiersTest.java
@@ -1,0 +1,59 @@
+package org.folio.recordgen;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+public class RoundRobinIdentifiersTest {
+
+  @Test
+  public void testConstructorWithEmptyIterable() {
+    RoundRobinIdentifiers identifiers = new RoundRobinIdentifiers(Collections.emptyList());
+    Assert.assertNull(identifiers.get());
+  }
+
+  @Test
+  public void testGetWithEmptyQueue() {
+    RoundRobinIdentifiers identifiers = new RoundRobinIdentifiers(Collections.emptyList());
+    Assert.assertNull(identifiers.get());
+  }
+
+  @Test
+  public void testGetWithSingleItemQueue() {
+    RoundRobinIdentifier roundRobinIdentifier = RoundRobinIdentifier.builder()
+      .instanceId("instanceId")
+      .holdingsId("holdingsId")
+      .itemId("itemId")
+      .sourceRecordId("sourceRecordId")
+      .build();
+
+    RoundRobinIdentifiers identifiers = new RoundRobinIdentifiers(Collections.singletonList(roundRobinIdentifier));
+    Assert.assertEquals(roundRobinIdentifier, identifiers.get());
+    Assert.assertEquals(roundRobinIdentifier, identifiers.get());
+    Assert.assertEquals(roundRobinIdentifier, identifiers.get());
+    Assert.assertEquals(roundRobinIdentifier, identifiers.next());
+    Assert.assertEquals(roundRobinIdentifier, identifiers.get());
+  }
+
+  @Test
+  public void testGetWithMultipleItemsQueue() {
+    RoundRobinIdentifier roundRobinIdentifier1 = new RoundRobinIdentifier(
+      "instanceId1", "holdingsId1", "itemId1", "authorityId","sourceRecordId1");
+    RoundRobinIdentifier roundRobinIdentifier2 = new RoundRobinIdentifier(
+      "instanceId2", "holdingsId2", "itemId2", "authorityId", "sourceRecordId2");
+    RoundRobinIdentifier roundRobinIdentifier3 = new RoundRobinIdentifier(
+      "instanceId3", "holdingsId3", "itemId3","authorityId", "sourceRecordId3");
+    RoundRobinIdentifiers identifiers = new RoundRobinIdentifiers(Arrays.asList(
+      roundRobinIdentifier1, roundRobinIdentifier2, roundRobinIdentifier3));
+    Assert.assertEquals(roundRobinIdentifier1, identifiers.get());
+    Assert.assertEquals(roundRobinIdentifier1, identifiers.get());
+    Assert.assertEquals(roundRobinIdentifier2, identifiers.next());
+    Assert.assertEquals(roundRobinIdentifier2, identifiers.get());
+    Assert.assertEquals(roundRobinIdentifier3, identifiers.next());
+    Assert.assertEquals(roundRobinIdentifier3, identifiers.get());
+    Assert.assertEquals(roundRobinIdentifier1, identifiers.next());
+    Assert.assertEquals(roundRobinIdentifier1, identifiers.get());
+  }
+}

--- a/job-profile-wrangler/src/test/resources/holdings_response.json
+++ b/job-profile-wrangler/src/test/resources/holdings_response.json
@@ -1,0 +1,27 @@
+{
+  "holdingsItems": [],
+  "bareHoldingsItems": [],
+  "id": "c5c90588-4163-46c5-9abe-2165843ec703",
+  "_version": 4,
+  "sourceId": "f32d531e-df79-46b3-8932-cdd35f7a2264",
+  "hrid": "ho00000000003",
+  "holdingsTypeId": "996f93e2-5b5e-4cf2-9168-33ced1f95eed",
+  "formerIds": [],
+  "instanceId": "7e2ad1dc-1f3b-4133-a975-2b08411b26c6",
+  "permanentLocationId": "184aae84-a5bf-4c6a-85ba-4a7c73026cd5",
+  "effectiveLocationId": "184aae84-a5bf-4c6a-85ba-4a7c73026cd5",
+  "electronicAccess": [],
+  "callNumberTypeId": "95467209-6d7b-468b-94df-0f5d7ad2747d",
+  "administrativeNotes": [],
+  "notes": [],
+  "holdingsStatements": [],
+  "holdingsStatementsForIndexes": [],
+  "holdingsStatementsForSupplements": [],
+  "statisticalCodeIds": [],
+  "metadata": {
+    "createdDate": "2024-05-14T17:55:56.536+00:00",
+    "createdByUserId": "8ca8e682-af58-40f8-b969-4a133c8a085c",
+    "updatedDate": "2024-05-15T22:39:01.570+00:00",
+    "updatedByUserId": "8ca8e682-af58-40f8-b969-4a133c8a085c"
+  }
+}

--- a/job-profile-wrangler/src/test/resources/instance_response.json
+++ b/job-profile-wrangler/src/test/resources/instance_response.json
@@ -1,0 +1,117 @@
+{
+  "id": "5beece6a-f008-4689-8155-bcc907c81476",
+  "_version": "1",
+  "hrid": "in00000000001",
+  "source": "MARC",
+  "title": "The Journal of ecclesiastical history.",
+  "administrativeNotes": [],
+  "indexTitle": "Journal of ecclesiastical history.",
+  "parentInstances": [],
+  "childInstances": [],
+  "isBoundWith": false,
+  "alternativeTitles": [],
+  "editions": [],
+  "series": [],
+  "identifiers": [
+    {
+      "identifierTypeId": "c858e4f2-2b6b-4385-842b-60732ee14abb",
+      "value": "58020553"
+    },
+    {
+      "identifierTypeId": "913300b2-03ed-469a-8179-c1092c991227",
+      "value": "0022-0469"
+    },
+    {
+      "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace",
+      "value": "(CStRLIN)NYCX1604275S"
+    },
+    {
+      "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace",
+      "value": "(NIC)notisABP6388"
+    },
+    {
+      "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace",
+      "value": "366832"
+    },
+    {
+      "identifierTypeId": "439bfbae-75bc-4f74-9fc7-b2a2d47ce3ef",
+      "value": "(OCoLC)1604275"
+    }
+  ],
+  "contributors": [
+    {
+      "authorityId": null,
+      "contributorNameTypeId": "2b94c631-fca9-4892-a730-03ee529ffe2a",
+      "name": "Dugmore, C. W. (Clifford William)",
+      "contributorTypeId": null,
+      "contributorTypeText": "ed.",
+      "primary": false
+    }
+  ],
+  "subjects": [
+    {
+      "authorityId": null,
+      "value": "Church history--Periodicals"
+    },
+    {
+      "authorityId": null,
+      "value": "Church history"
+    },
+    {
+      "authorityId": null,
+      "value": "Periodicals"
+    }
+  ],
+  "classifications": [
+    {
+      "classificationNumber": "BR140 .J6",
+      "classificationTypeId": "ce176ace-a53e-4b4d-aa89-725ed7b2edac"
+    },
+    {
+      "classificationNumber": "270.05",
+      "classificationTypeId": "42471af9-7d25-4f3a-bf78-60d29dcf463b"
+    }
+  ],
+  "publication": [
+    {
+      "publisher": "Cambridge University Press [etc.]",
+      "place": "London",
+      "dateOfPublication": null,
+      "role": null
+    }
+  ],
+  "publicationFrequency": [
+    "Quarterly, 1970-",
+    "Semiannual, 1950-69"
+  ],
+  "publicationRange": [
+    "v. 1-   Apr. 1950-"
+  ],
+  "electronicAccess": [],
+  "instanceTypeId": "30fffe0e-e985-4144-b2e2-1e8179bdb41f",
+  "instanceFormatIds": [],
+  "physicalDescriptions": [
+    "v. 25 cm."
+  ],
+  "languages": [
+    "eng"
+  ],
+  "notes": [],
+  "modeOfIssuanceId": "068b5344-e2a6-40df-9186-1829e13cd344",
+  "previouslyHeld": false,
+  "discoverySuppress": false,
+  "statisticalCodeIds": [],
+  "statusUpdatedDate": "2024-05-14T12:25:52.634+0000",
+  "metadata": {
+    "createdDate": "2024-05-14T12:25:52.634+00:00",
+    "createdByUserId": "8ca8e682-af58-40f8-b969-4a133c8a085c",
+    "updatedDate": "2024-05-14T12:25:52.634+00:00",
+    "updatedByUserId": "8ca8e682-af58-40f8-b969-4a133c8a085c"
+  },
+  "tags": {
+    "tagList": []
+  },
+  "natureOfContentTermIds": [],
+  "precedingTitles": [],
+  "succeedingTitles": []
+}

--- a/job-profile-wrangler/src/test/resources/job_profile_snapshot.json
+++ b/job-profile-wrangler/src/test/resources/job_profile_snapshot.json
@@ -1,10 +1,10 @@
 {
-  "id" : "44f4a6c4-4504-4f53-b25c-f7fcba5faeae",
-  "profileId" : "e792f71f-7114-456c-acff-f83b49467329",
-  "profileWrapperId" : "fbc19c85-6757-4fb3-8af7-2c49b8814a1c",
+  "id" : "51a675b5-a017-4a67-8cf5-bc58b909f9a3",
+  "profileId" : "a6d9ab9d-ee7e-4c17-8b21-e367dd6108b1",
+  "profileWrapperId" : "fb0ed96f-db9c-4e05-850d-79115c3c4c60",
   "contentType" : "JOB_PROFILE",
   "content" : {
-    "id" : "e792f71f-7114-456c-acff-f83b49467329",
+    "id" : "a6d9ab9d-ee7e-4c17-8b21-e367dd6108b1",
     "name" : "test",
     "description" : "",
     "dataType" : "MARC",
@@ -18,92 +18,358 @@
     "childProfiles" : [ ],
     "hidden" : false,
     "metadata" : {
-      "createdDate" : "2024-04-23T17:53:51.054+00:00",
-      "createdByUserId" : "62314909-930d-5898-bfaf-3bcf9dab6e85",
-      "updatedDate" : "2024-04-23T17:53:51.054+00:00",
-      "updatedByUserId" : "62314909-930d-5898-bfaf-3bcf9dab6e85"
+      "createdDate" : "2024-05-01T17:13:00.054+00:00",
+      "createdByUserId" : "91261c44-87bf-5bab-948f-c27090d4e05c",
+      "updatedDate" : "2024-05-01T17:13:00.054+00:00",
+      "updatedByUserId" : "91261c44-87bf-5bab-948f-c27090d4e05c"
     }
   },
   "order" : 0,
   "childSnapshotWrappers" : [ {
-    "id" : "938de050-7a39-4dd0-adb8-82a4159b2316",
-    "profileId" : "d8706411-bdd6-4070-b43e-2ed04f2ada28",
-    "profileWrapperId" : "a91ae4b6-20b6-4346-927d-9b056c94e6d1",
+    "id" : "55776da6-84ee-4acf-822a-3fb19c768cd1",
+    "profileId" : "31dbb554-0826-48ec-a0a4-3c55293d4dee",
+    "profileWrapperId" : "5296c93b-baca-4999-ac15-a568de91bd3e",
     "contentType" : "MATCH_PROFILE",
     "content" : {
-      "id" : "d8706411-bdd6-4070-b43e-2ed04f2ada28",
-      "name" : "jp-2 BODWR-202404231118",
+      "id" : "31dbb554-0826-48ec-a0a4-3c55293d4dee",
+      "name" : "Inventory Single Record - Default match for no SRS record",
+      "description" : "Matches the Instance UUID from the 999 ff $i in the incoming MARC record to the UUID of the existing Instance record",
       "incomingRecordType" : "MARC_BIBLIOGRAPHIC",
-      "existingRecordType" : "MARC_BIBLIOGRAPHIC",
-      "matchDetails" : [ ],
+      "existingRecordType" : "INSTANCE",
+      "matchDetails" : [ {
+        "incomingRecordType" : "MARC_BIBLIOGRAPHIC",
+        "existingRecordType" : "INSTANCE",
+        "incomingMatchExpression" : {
+          "dataValueType" : "VALUE_FROM_RECORD",
+          "fields" : [ {
+            "label" : "field",
+            "value" : "999"
+          }, {
+            "label" : "indicator1",
+            "value" : "f"
+          }, {
+            "label" : "indicator2",
+            "value" : "f"
+          }, {
+            "label" : "recordSubfield",
+            "value" : "i"
+          } ]
+        },
+        "matchCriterion" : "EXACTLY_MATCHES",
+        "existingMatchExpression" : {
+          "dataValueType" : "VALUE_FROM_RECORD",
+          "fields" : [ {
+            "label" : "field",
+            "value" : "instance.id"
+          } ]
+        }
+      } ],
       "deleted" : false,
       "userInfo" : {
-        "firstName" : "DIKU",
-        "lastName" : "ADMINISTRATOR",
-        "userName" : "diku_admin"
+        "firstName" : "System",
+        "lastName" : "System",
+        "userName" : "System"
       },
       "parentProfiles" : [ ],
       "childProfiles" : [ ],
       "hidden" : false,
       "metadata" : {
-        "createdDate" : "2024-04-23T16:18:04.400+00:00",
-        "createdByUserId" : "62314909-930d-5898-bfaf-3bcf9dab6e85",
-        "updatedDate" : "2024-04-23T16:18:04.400+00:00",
-        "updatedByUserId" : "62314909-930d-5898-bfaf-3bcf9dab6e85"
+        "createdDate" : "2020-11-30T09:06:57.367+00:00",
+        "createdByUserId" : "6a010e5b-5421-5b1c-9b52-568b37038575",
+        "updatedDate" : "2020-11-30T10:00:10.359+00:00",
+        "updatedByUserId" : "6a010e5b-5421-5b1c-9b52-568b37038575"
       }
     },
     "order" : 0,
     "childSnapshotWrappers" : [ {
-      "id" : "b496f196-f8f3-404b-b640-43dfaf0c4088",
-      "profileId" : "db474655-9c78-4171-9ab4-39363986d5c6",
-      "profileWrapperId" : "96777875-885c-4811-bdda-738823047dd2",
-      "contentType" : "MATCH_PROFILE",
+      "id" : "6b6953ff-fa3e-4c17-a759-857e7de1c41d",
+      "profileId" : "fa45f3ec-9b83-11eb-a8b3-0242ac130003",
+      "profileWrapperId" : "359c13ca-6022-4809-a364-4dc03ced9df7",
+      "contentType" : "ACTION_PROFILE",
       "reactTo" : "MATCH",
       "content" : {
-        "id" : "db474655-9c78-4171-9ab4-39363986d5c6",
-        "name" : "jp-2 GPHWV-202404231138",
-        "incomingRecordType" : "MARC_BIBLIOGRAPHIC",
-        "existingRecordType" : "MARC_BIBLIOGRAPHIC",
-        "matchDetails" : [ ],
+        "id" : "fa45f3ec-9b83-11eb-a8b3-0242ac130003",
+        "name" : "Default - Create instance",
+        "description" : "This action profile is used with FOLIO's default job profile for creating Inventory Instances and SRS MARC Bibliographic records. It can be edited, duplicated, or deleted.",
+        "action" : "CREATE",
+        "folioRecord" : "INSTANCE",
         "deleted" : false,
         "userInfo" : {
-          "firstName" : "DIKU",
-          "lastName" : "ADMINISTRATOR",
-          "userName" : "diku_admin"
+          "firstName" : "System",
+          "lastName" : "System",
+          "userName" : "System"
         },
         "parentProfiles" : [ ],
         "childProfiles" : [ ],
         "hidden" : false,
+        "remove9Subfields" : true,
         "metadata" : {
-          "createdDate" : "2024-04-23T16:39:02.191+00:00",
-          "createdByUserId" : "62314909-930d-5898-bfaf-3bcf9dab6e85",
-          "updatedDate" : "2024-04-23T16:39:02.191+00:00",
-          "updatedByUserId" : "62314909-930d-5898-bfaf-3bcf9dab6e85"
+          "createdDate" : "2021-04-13T14:00:00.000+00:00",
+          "createdByUserId" : "00000000-0000-0000-0000-000000000000",
+          "updatedDate" : "2021-04-13T15:00:00.462+00:00",
+          "updatedByUserId" : "00000000-0000-0000-0000-000000000000"
         }
       },
       "order" : 0,
       "childSnapshotWrappers" : [ {
-        "id" : "4e3c724e-d390-4ff0-a62e-436739fa31fd",
-        "profileId" : "fa45f3ec-9b83-11eb-a8b3-0242ac130003",
-        "profileWrapperId" : "e249d594-ab06-4a17-a4ad-af783c79b6bb",
-        "contentType" : "ACTION_PROFILE",
-        "reactTo" : "MATCH",
+        "id" : "2325f486-7ce4-48ac-a4c2-c87d131ec901",
+        "profileId" : "bf7b3b86-9b84-11eb-a8b3-0242ac130003",
+        "profileWrapperId" : "c1fe85bb-5cf4-42ec-a949-aa7649429351",
+        "contentType" : "MAPPING_PROFILE",
         "content" : {
-          "id" : "fa45f3ec-9b83-11eb-a8b3-0242ac130003",
+          "id" : "bf7b3b86-9b84-11eb-a8b3-0242ac130003",
           "name" : "Default - Create instance",
-          "description" : "This action profile is used with FOLIO's default job profile for creating Inventory Instances and SRS MARC Bibliographic records. It can be edited, duplicated, or deleted.",
-          "action" : "CREATE",
-          "folioRecord" : "INSTANCE",
+          "description" : "This field mapping profile is used with FOLIO's default job profile for creating Inventory Instances and SRS MARC Bibliographic records. It can be edited, duplicated, deleted, or linked to additional action profiles.",
+          "incomingRecordType" : "MARC_BIBLIOGRAPHIC",
+          "existingRecordType" : "INSTANCE",
           "deleted" : false,
           "userInfo" : {
             "firstName" : "System",
             "lastName" : "System",
             "userName" : "System"
           },
+          "marcFieldProtectionSettings" : [ ],
           "parentProfiles" : [ ],
           "childProfiles" : [ ],
+          "mappingDetails" : {
+            "name" : "instance",
+            "recordType" : "INSTANCE",
+            "mappingFields" : [ {
+              "name" : "discoverySuppress",
+              "enabled" : "true",
+              "required" : false,
+              "path" : "instance.discoverySuppress",
+              "value" : "",
+              "subfields" : [ ]
+            }, {
+              "name" : "staffSuppress",
+              "enabled" : "true",
+              "required" : false,
+              "path" : "instance.staffSuppress",
+              "value" : "",
+              "subfields" : [ ]
+            }, {
+              "name" : "previouslyHeld",
+              "enabled" : "true",
+              "required" : false,
+              "path" : "instance.previouslyHeld",
+              "value" : "",
+              "subfields" : [ ]
+            }, {
+              "name" : "hrid",
+              "enabled" : "false",
+              "required" : false,
+              "path" : "instance.hrid",
+              "value" : "",
+              "subfields" : [ ]
+            }, {
+              "name" : "source",
+              "enabled" : "false",
+              "required" : false,
+              "path" : "instance.source",
+              "value" : "",
+              "subfields" : [ ]
+            }, {
+              "name" : "catalogedDate",
+              "enabled" : "true",
+              "required" : false,
+              "path" : "instance.catalogedDate",
+              "value" : "",
+              "subfields" : [ ]
+            }, {
+              "name" : "statusId",
+              "enabled" : "true",
+              "required" : false,
+              "path" : "instance.statusId",
+              "value" : "",
+              "subfields" : [ ],
+              "acceptedValues" : {
+                "26f5208e-110a-4394-be29-1569a8c84a65" : "Uncataloged",
+                "52a2ff34-2a12-420d-8539-21aa8d3cf5d8" : "Batch Loaded",
+                "f5cc2ab6-bb92-4cab-b83f-5a3d09261a41" : "Not yet assigned",
+                "2a340d34-6b70-443a-bb1b-1b8d1c65d862" : "Other",
+                "9634a5ab-9228-4703-baf2-4d12ebc77d56" : "Cataloged",
+                "daf2681c-25af-4202-a3fa-e58fdf806183" : "Temporary"
+              }
+            }, {
+              "name" : "modeOfIssuanceId",
+              "enabled" : "false",
+              "required" : false,
+              "path" : "instance.modeOfIssuanceId",
+              "value" : "",
+              "subfields" : [ ]
+            }, {
+              "name" : "statisticalCodeIds",
+              "enabled" : "true",
+              "required" : false,
+              "path" : "instance.statisticalCodeIds[]",
+              "value" : "",
+              "subfields" : [ ]
+            }, {
+              "name" : "title",
+              "enabled" : "false",
+              "required" : false,
+              "path" : "instance.title",
+              "value" : "",
+              "subfields" : [ ]
+            }, {
+              "name" : "alternativeTitles",
+              "enabled" : "false",
+              "required" : false,
+              "path" : "instance.alternativeTitles[]",
+              "value" : "",
+              "subfields" : [ ]
+            }, {
+              "name" : "indexTitle",
+              "enabled" : "false",
+              "required" : false,
+              "path" : "instance.indexTitle",
+              "value" : "",
+              "subfields" : [ ]
+            }, {
+              "name" : "series",
+              "enabled" : "false",
+              "required" : false,
+              "path" : "instance.series[]",
+              "value" : "",
+              "subfields" : [ ]
+            }, {
+              "name" : "precedingTitles",
+              "enabled" : "false",
+              "required" : false,
+              "path" : "instance.precedingTitles[]",
+              "value" : "",
+              "subfields" : [ ]
+            }, {
+              "name" : "succeedingTitles",
+              "enabled" : "false",
+              "required" : false,
+              "path" : "instance.succeedingTitles[]",
+              "value" : "",
+              "subfields" : [ ]
+            }, {
+              "name" : "identifiers",
+              "enabled" : "false",
+              "required" : false,
+              "path" : "instance.identifiers[]",
+              "value" : "",
+              "subfields" : [ ]
+            }, {
+              "name" : "contributors",
+              "enabled" : "false",
+              "required" : false,
+              "path" : "instance.contributors[]",
+              "value" : "",
+              "subfields" : [ ]
+            }, {
+              "name" : "publication",
+              "enabled" : "false",
+              "required" : false,
+              "path" : "instance.publication[]",
+              "value" : "",
+              "subfields" : [ ]
+            }, {
+              "name" : "editions",
+              "enabled" : "false",
+              "required" : false,
+              "path" : "instance.editions[]",
+              "value" : "",
+              "subfields" : [ ]
+            }, {
+              "name" : "physicalDescriptions",
+              "enabled" : "false",
+              "required" : false,
+              "path" : "instance.physicalDescriptions[]",
+              "value" : "",
+              "subfields" : [ ]
+            }, {
+              "name" : "instanceTypeId",
+              "enabled" : "false",
+              "required" : false,
+              "path" : "instance.instanceTypeId",
+              "value" : "",
+              "subfields" : [ ]
+            }, {
+              "name" : "natureOfContentTermIds",
+              "enabled" : "true",
+              "required" : false,
+              "path" : "instance.natureOfContentTermIds[]",
+              "value" : "",
+              "subfields" : [ ]
+            }, {
+              "name" : "instanceFormatIds",
+              "enabled" : "false",
+              "required" : false,
+              "path" : "instance.instanceFormatIds[]",
+              "value" : "",
+              "subfields" : [ ]
+            }, {
+              "name" : "languages",
+              "enabled" : "false",
+              "required" : false,
+              "path" : "instance.languages[]",
+              "value" : "",
+              "subfields" : [ ]
+            }, {
+              "name" : "publicationFrequency",
+              "enabled" : "false",
+              "required" : false,
+              "path" : "instance.publicationFrequency[]",
+              "value" : "",
+              "subfields" : [ ]
+            }, {
+              "name" : "publicationRange",
+              "enabled" : "false",
+              "required" : false,
+              "path" : "instance.publicationRange[]",
+              "value" : "",
+              "subfields" : [ ]
+            }, {
+              "name" : "notes",
+              "enabled" : "false",
+              "required" : false,
+              "path" : "instance.notes[]",
+              "value" : "",
+              "subfields" : [ ]
+            }, {
+              "name" : "electronicAccess",
+              "enabled" : "false",
+              "required" : false,
+              "path" : "instance.electronicAccess[]",
+              "value" : "",
+              "subfields" : [ ]
+            }, {
+              "name" : "subjects",
+              "enabled" : "false",
+              "required" : false,
+              "path" : "instance.subjects[]",
+              "value" : "",
+              "subfields" : [ ]
+            }, {
+              "name" : "classifications",
+              "enabled" : "false",
+              "required" : false,
+              "path" : "instance.classifications[]",
+              "value" : "",
+              "subfields" : [ ]
+            }, {
+              "name" : "parentInstances",
+              "enabled" : "true",
+              "required" : false,
+              "path" : "instance.parentInstances[]",
+              "value" : "",
+              "subfields" : [ ]
+            }, {
+              "name" : "childInstances",
+              "enabled" : "true",
+              "required" : false,
+              "path" : "instance.childInstances[]",
+              "value" : "",
+              "subfields" : [ ]
+            } ],
+            "marcMappingDetails" : [ ]
+          },
           "hidden" : false,
-          "remove9Subfields" : true,
           "metadata" : {
             "createdDate" : "2021-04-13T14:00:00.000+00:00",
             "createdByUserId" : "00000000-0000-0000-0000-000000000000",
@@ -112,275 +378,7 @@
           }
         },
         "order" : 0,
-        "childSnapshotWrappers" : [ {
-          "id" : "af352a3a-c955-432d-99d1-8ef6b45333e1",
-          "profileId" : "bf7b3b86-9b84-11eb-a8b3-0242ac130003",
-          "profileWrapperId" : "b350db9b-0df2-4e9d-bb10-b6697d5f880e",
-          "contentType" : "MAPPING_PROFILE",
-          "content" : {
-            "id" : "bf7b3b86-9b84-11eb-a8b3-0242ac130003",
-            "name" : "Default - Create instance",
-            "description" : "This field mapping profile is used with FOLIO's default job profile for creating Inventory Instances and SRS MARC Bibliographic records. It can be edited, duplicated, deleted, or linked to additional action profiles.",
-            "incomingRecordType" : "MARC_BIBLIOGRAPHIC",
-            "existingRecordType" : "INSTANCE",
-            "deleted" : false,
-            "userInfo" : {
-              "firstName" : "System",
-              "lastName" : "System",
-              "userName" : "System"
-            },
-            "marcFieldProtectionSettings" : [ ],
-            "parentProfiles" : [ ],
-            "childProfiles" : [ ],
-            "mappingDetails" : {
-              "name" : "instance",
-              "recordType" : "INSTANCE",
-              "mappingFields" : [ {
-                "name" : "discoverySuppress",
-                "enabled" : "true",
-                "required" : false,
-                "path" : "instance.discoverySuppress",
-                "value" : "",
-                "subfields" : [ ]
-              }, {
-                "name" : "staffSuppress",
-                "enabled" : "true",
-                "required" : false,
-                "path" : "instance.staffSuppress",
-                "value" : "",
-                "subfields" : [ ]
-              }, {
-                "name" : "previouslyHeld",
-                "enabled" : "true",
-                "required" : false,
-                "path" : "instance.previouslyHeld",
-                "value" : "",
-                "subfields" : [ ]
-              }, {
-                "name" : "hrid",
-                "enabled" : "false",
-                "required" : false,
-                "path" : "instance.hrid",
-                "value" : "",
-                "subfields" : [ ]
-              }, {
-                "name" : "source",
-                "enabled" : "false",
-                "required" : false,
-                "path" : "instance.source",
-                "value" : "",
-                "subfields" : [ ]
-              }, {
-                "name" : "catalogedDate",
-                "enabled" : "true",
-                "required" : false,
-                "path" : "instance.catalogedDate",
-                "value" : "",
-                "subfields" : [ ]
-              }, {
-                "name" : "statusId",
-                "enabled" : "true",
-                "required" : false,
-                "path" : "instance.statusId",
-                "value" : "",
-                "subfields" : [ ],
-                "acceptedValues" : {
-                  "26f5208e-110a-4394-be29-1569a8c84a65" : "Uncataloged",
-                  "52a2ff34-2a12-420d-8539-21aa8d3cf5d8" : "Batch Loaded",
-                  "f5cc2ab6-bb92-4cab-b83f-5a3d09261a41" : "Not yet assigned",
-                  "2a340d34-6b70-443a-bb1b-1b8d1c65d862" : "Other",
-                  "9634a5ab-9228-4703-baf2-4d12ebc77d56" : "Cataloged",
-                  "daf2681c-25af-4202-a3fa-e58fdf806183" : "Temporary"
-                }
-              }, {
-                "name" : "modeOfIssuanceId",
-                "enabled" : "false",
-                "required" : false,
-                "path" : "instance.modeOfIssuanceId",
-                "value" : "",
-                "subfields" : [ ]
-              }, {
-                "name" : "statisticalCodeIds",
-                "enabled" : "true",
-                "required" : false,
-                "path" : "instance.statisticalCodeIds[]",
-                "value" : "",
-                "subfields" : [ ]
-              }, {
-                "name" : "title",
-                "enabled" : "false",
-                "required" : false,
-                "path" : "instance.title",
-                "value" : "",
-                "subfields" : [ ]
-              }, {
-                "name" : "alternativeTitles",
-                "enabled" : "false",
-                "required" : false,
-                "path" : "instance.alternativeTitles[]",
-                "value" : "",
-                "subfields" : [ ]
-              }, {
-                "name" : "indexTitle",
-                "enabled" : "false",
-                "required" : false,
-                "path" : "instance.indexTitle",
-                "value" : "",
-                "subfields" : [ ]
-              }, {
-                "name" : "series",
-                "enabled" : "false",
-                "required" : false,
-                "path" : "instance.series[]",
-                "value" : "",
-                "subfields" : [ ]
-              }, {
-                "name" : "precedingTitles",
-                "enabled" : "false",
-                "required" : false,
-                "path" : "instance.precedingTitles[]",
-                "value" : "",
-                "subfields" : [ ]
-              }, {
-                "name" : "succeedingTitles",
-                "enabled" : "false",
-                "required" : false,
-                "path" : "instance.succeedingTitles[]",
-                "value" : "",
-                "subfields" : [ ]
-              }, {
-                "name" : "identifiers",
-                "enabled" : "false",
-                "required" : false,
-                "path" : "instance.identifiers[]",
-                "value" : "",
-                "subfields" : [ ]
-              }, {
-                "name" : "contributors",
-                "enabled" : "false",
-                "required" : false,
-                "path" : "instance.contributors[]",
-                "value" : "",
-                "subfields" : [ ]
-              }, {
-                "name" : "publication",
-                "enabled" : "false",
-                "required" : false,
-                "path" : "instance.publication[]",
-                "value" : "",
-                "subfields" : [ ]
-              }, {
-                "name" : "editions",
-                "enabled" : "false",
-                "required" : false,
-                "path" : "instance.editions[]",
-                "value" : "",
-                "subfields" : [ ]
-              }, {
-                "name" : "physicalDescriptions",
-                "enabled" : "false",
-                "required" : false,
-                "path" : "instance.physicalDescriptions[]",
-                "value" : "",
-                "subfields" : [ ]
-              }, {
-                "name" : "instanceTypeId",
-                "enabled" : "false",
-                "required" : false,
-                "path" : "instance.instanceTypeId",
-                "value" : "",
-                "subfields" : [ ]
-              }, {
-                "name" : "natureOfContentTermIds",
-                "enabled" : "true",
-                "required" : false,
-                "path" : "instance.natureOfContentTermIds[]",
-                "value" : "",
-                "subfields" : [ ]
-              }, {
-                "name" : "instanceFormatIds",
-                "enabled" : "false",
-                "required" : false,
-                "path" : "instance.instanceFormatIds[]",
-                "value" : "",
-                "subfields" : [ ]
-              }, {
-                "name" : "languages",
-                "enabled" : "false",
-                "required" : false,
-                "path" : "instance.languages[]",
-                "value" : "",
-                "subfields" : [ ]
-              }, {
-                "name" : "publicationFrequency",
-                "enabled" : "false",
-                "required" : false,
-                "path" : "instance.publicationFrequency[]",
-                "value" : "",
-                "subfields" : [ ]
-              }, {
-                "name" : "publicationRange",
-                "enabled" : "false",
-                "required" : false,
-                "path" : "instance.publicationRange[]",
-                "value" : "",
-                "subfields" : [ ]
-              }, {
-                "name" : "notes",
-                "enabled" : "false",
-                "required" : false,
-                "path" : "instance.notes[]",
-                "value" : "",
-                "subfields" : [ ]
-              }, {
-                "name" : "electronicAccess",
-                "enabled" : "false",
-                "required" : false,
-                "path" : "instance.electronicAccess[]",
-                "value" : "",
-                "subfields" : [ ]
-              }, {
-                "name" : "subjects",
-                "enabled" : "false",
-                "required" : false,
-                "path" : "instance.subjects[]",
-                "value" : "",
-                "subfields" : [ ]
-              }, {
-                "name" : "classifications",
-                "enabled" : "false",
-                "required" : false,
-                "path" : "instance.classifications[]",
-                "value" : "",
-                "subfields" : [ ]
-              }, {
-                "name" : "parentInstances",
-                "enabled" : "true",
-                "required" : false,
-                "path" : "instance.parentInstances[]",
-                "value" : "",
-                "subfields" : [ ]
-              }, {
-                "name" : "childInstances",
-                "enabled" : "true",
-                "required" : false,
-                "path" : "instance.childInstances[]",
-                "value" : "",
-                "subfields" : [ ]
-              } ],
-              "marcMappingDetails" : [ ]
-            },
-            "hidden" : false,
-            "metadata" : {
-              "createdDate" : "2021-04-13T14:00:00.000+00:00",
-              "createdByUserId" : "00000000-0000-0000-0000-000000000000",
-              "updatedDate" : "2021-04-13T15:00:00.462+00:00",
-              "updatedByUserId" : "00000000-0000-0000-0000-000000000000"
-            }
-          },
-          "order" : 0,
-          "childSnapshotWrappers" : [ ]
-        } ]
+        "childSnapshotWrappers" : [ ]
       } ]
     } ]
   } ]

--- a/job-profile-wrangler/src/test/resources/record_gen_job_profile_snapshot.json
+++ b/job-profile-wrangler/src/test/resources/record_gen_job_profile_snapshot.json
@@ -1,0 +1,1160 @@
+{
+  "id" : "19a8dffa-2af6-4bc4-95cb-44163c4345cb",
+  "profileId" : "0db1f720-e396-4c2b-8238-c2f0aaf032c0",
+  "profileWrapperId" : "4dcfae9e-1149-407f-af02-c36572ea1855",
+  "contentType" : "JOB_PROFILE",
+  "content" : {
+    "id" : "0db1f720-e396-4c2b-8238-c2f0aaf032c0",
+    "name" : "Record Gen",
+    "description" : "",
+    "dataType" : "MARC",
+    "deleted" : false,
+    "userInfo" : {
+      "firstName" : "",
+      "lastName" : "Superuser",
+      "userName" : "diku_admin"
+    },
+    "parentProfiles" : [ ],
+    "childProfiles" : [ ],
+    "hidden" : false,
+    "metadata" : {
+      "createdDate" : "2024-05-15T15:37:24.361+00:00",
+      "createdByUserId" : "8ca8e682-af58-40f8-b969-4a133c8a085c",
+      "updatedDate" : "2024-05-16T07:05:57.324+00:00",
+      "updatedByUserId" : "8ca8e682-af58-40f8-b969-4a133c8a085c"
+    }
+  },
+  "order" : 0,
+  "childSnapshotWrappers" : [ {
+    "id" : "6501cfc7-c294-44e3-943f-15a026f38e69",
+    "profileId" : "d27d71ce-8a1e-44c6-acea-96961b5592c6",
+    "profileWrapperId" : "96dde2e2-e362-408f-b659-3e47054f7dab",
+    "contentType" : "MATCH_PROFILE",
+    "content" : {
+      "id" : "d27d71ce-8a1e-44c6-acea-96961b5592c6",
+      "name" : "Inventory Single Record - Default match for existing SRS record",
+      "description" : "Matches the Instance UUID from the 999 ff $i in the incoming MARC record to the same field in any SRS MARC Bib",
+      "incomingRecordType" : "MARC_BIBLIOGRAPHIC",
+      "existingRecordType" : "MARC_BIBLIOGRAPHIC",
+      "matchDetails" : [ {
+        "incomingRecordType" : "MARC_BIBLIOGRAPHIC",
+        "existingRecordType" : "MARC_BIBLIOGRAPHIC",
+        "incomingMatchExpression" : {
+          "dataValueType" : "VALUE_FROM_RECORD",
+          "fields" : [ {
+            "label" : "field",
+            "value" : "999"
+          }, {
+            "label" : "indicator1",
+            "value" : "f"
+          }, {
+            "label" : "indicator2",
+            "value" : "f"
+          }, {
+            "label" : "recordSubfield",
+            "value" : "i"
+          } ]
+        },
+        "matchCriterion" : "EXACTLY_MATCHES",
+        "existingMatchExpression" : {
+          "dataValueType" : "VALUE_FROM_RECORD",
+          "fields" : [ {
+            "label" : "field",
+            "value" : "999"
+          }, {
+            "label" : "indicator1",
+            "value" : "f"
+          }, {
+            "label" : "indicator2",
+            "value" : "f"
+          }, {
+            "label" : "recordSubfield",
+            "value" : "i"
+          } ]
+        }
+      } ],
+      "deleted" : false,
+      "userInfo" : {
+        "firstName" : "System",
+        "lastName" : "System",
+        "userName" : "System"
+      },
+      "parentProfiles" : [ ],
+      "childProfiles" : [ ],
+      "hidden" : false,
+      "metadata" : {
+        "createdDate" : "2020-11-30T09:06:01.520+00:00",
+        "createdByUserId" : "6a010e5b-5421-5b1c-9b52-568b37038575",
+        "updatedDate" : "2020-11-30T09:59:01.248+00:00",
+        "updatedByUserId" : "6a010e5b-5421-5b1c-9b52-568b37038575"
+      }
+    },
+    "order" : 0,
+    "childSnapshotWrappers" : [ {
+      "id" : "260033c2-13a5-4967-9726-145b3a5c81dd",
+      "profileId" : "31ccc13e-fc14-4d2d-899b-eacabb3ca6f3",
+      "profileWrapperId" : "4df5e5b9-bb45-4db7-ae73-795da3428a02",
+      "contentType" : "MATCH_PROFILE",
+      "reactTo" : "NON_MATCH",
+      "content" : {
+        "id" : "31ccc13e-fc14-4d2d-899b-eacabb3ca6f3",
+        "name" : "Match static value \"test\" with 445a",
+        "description" : "",
+        "incomingRecordType" : "STATIC_VALUE",
+        "existingRecordType" : "MARC_BIBLIOGRAPHIC",
+        "matchDetails" : [ {
+          "incomingRecordType" : "STATIC_VALUE",
+          "existingRecordType" : "MARC_BIBLIOGRAPHIC",
+          "incomingMatchExpression" : {
+            "dataValueType" : "STATIC_VALUE",
+            "fields" : [ ],
+            "staticValueDetails" : {
+              "staticValueType" : "TEXT",
+              "text" : "test",
+              "number" : ""
+            }
+          },
+          "matchCriterion" : "EXACTLY_MATCHES",
+          "existingMatchExpression" : {
+            "dataValueType" : "VALUE_FROM_RECORD",
+            "fields" : [ {
+              "label" : "field",
+              "value" : "445"
+            }, {
+              "label" : "indicator1",
+              "value" : ""
+            }, {
+              "label" : "indicator2",
+              "value" : ""
+            }, {
+              "label" : "recordSubfield",
+              "value" : "a"
+            } ]
+          }
+        } ],
+        "deleted" : false,
+        "userInfo" : {
+          "firstName" : "",
+          "lastName" : "Superuser",
+          "userName" : "diku_admin"
+        },
+        "parentProfiles" : [ ],
+        "childProfiles" : [ ],
+        "hidden" : false,
+        "metadata" : {
+          "createdDate" : "2024-05-16T06:47:56.531+00:00",
+          "createdByUserId" : "8ca8e682-af58-40f8-b969-4a133c8a085c",
+          "updatedDate" : "2024-05-16T06:47:56.531+00:00",
+          "updatedByUserId" : "8ca8e682-af58-40f8-b969-4a133c8a085c"
+        }
+      },
+      "order" : 0,
+      "childSnapshotWrappers" : [ {
+        "id" : "30f76089-085d-4bee-91c5-018bb0292feb",
+        "profileId" : "fa45f3ec-9b83-11eb-a8b3-0242ac130003",
+        "profileWrapperId" : "02b30f94-db35-4701-81fd-c00e5ac01cce",
+        "contentType" : "ACTION_PROFILE",
+        "reactTo" : "MATCH",
+        "content" : {
+          "id" : "fa45f3ec-9b83-11eb-a8b3-0242ac130003",
+          "name" : "Default - Create instance",
+          "description" : "This action profile is used with FOLIO's default job profile for creating Inventory Instances and SRS MARC Bibliographic records. It can be edited, duplicated, or deleted.",
+          "action" : "CREATE",
+          "folioRecord" : "INSTANCE",
+          "deleted" : false,
+          "userInfo" : {
+            "firstName" : "System",
+            "lastName" : "System",
+            "userName" : "System"
+          },
+          "parentProfiles" : [ ],
+          "childProfiles" : [ ],
+          "hidden" : false,
+          "remove9Subfields" : true,
+          "metadata" : {
+            "createdDate" : "2021-04-13T14:00:00.000+00:00",
+            "createdByUserId" : "00000000-0000-0000-0000-000000000000",
+            "updatedDate" : "2021-04-13T15:00:00.462+00:00",
+            "updatedByUserId" : "00000000-0000-0000-0000-000000000000"
+          }
+        },
+        "order" : 0,
+        "childSnapshotWrappers" : [ {
+          "id" : "08a70824-107b-4d81-bf1c-6326a44e22e8",
+          "profileId" : "bf7b3b86-9b84-11eb-a8b3-0242ac130003",
+          "profileWrapperId" : "3ebe30ff-27d3-41f8-9457-4410cbca813d",
+          "contentType" : "MAPPING_PROFILE",
+          "content" : {
+            "id" : "bf7b3b86-9b84-11eb-a8b3-0242ac130003",
+            "name" : "Default - Create instance",
+            "description" : "This field mapping profile is used with FOLIO's default job profile for creating Inventory Instances and SRS MARC Bibliographic records. It can be edited, duplicated, deleted, or linked to additional action profiles.",
+            "incomingRecordType" : "MARC_BIBLIOGRAPHIC",
+            "existingRecordType" : "INSTANCE",
+            "deleted" : false,
+            "userInfo" : {
+              "firstName" : "System",
+              "lastName" : "System",
+              "userName" : "System"
+            },
+            "marcFieldProtectionSettings" : [ ],
+            "parentProfiles" : [ ],
+            "childProfiles" : [ ],
+            "mappingDetails" : {
+              "name" : "instance",
+              "recordType" : "INSTANCE",
+              "mappingFields" : [ {
+                "name" : "discoverySuppress",
+                "enabled" : "true",
+                "required" : false,
+                "path" : "instance.discoverySuppress",
+                "value" : "",
+                "subfields" : [ ]
+              }, {
+                "name" : "staffSuppress",
+                "enabled" : "true",
+                "required" : false,
+                "path" : "instance.staffSuppress",
+                "value" : "",
+                "subfields" : [ ]
+              }, {
+                "name" : "previouslyHeld",
+                "enabled" : "true",
+                "required" : false,
+                "path" : "instance.previouslyHeld",
+                "value" : "",
+                "subfields" : [ ]
+              }, {
+                "name" : "hrid",
+                "enabled" : "false",
+                "required" : false,
+                "path" : "instance.hrid",
+                "value" : "",
+                "subfields" : [ ]
+              }, {
+                "name" : "source",
+                "enabled" : "false",
+                "required" : false,
+                "path" : "instance.source",
+                "value" : "",
+                "subfields" : [ ]
+              }, {
+                "name" : "catalogedDate",
+                "enabled" : "true",
+                "required" : false,
+                "path" : "instance.catalogedDate",
+                "value" : "",
+                "subfields" : [ ]
+              }, {
+                "name" : "statusId",
+                "enabled" : "true",
+                "required" : false,
+                "path" : "instance.statusId",
+                "value" : "",
+                "subfields" : [ ],
+                "acceptedValues" : {
+                  "26f5208e-110a-4394-be29-1569a8c84a65" : "Uncataloged",
+                  "52a2ff34-2a12-420d-8539-21aa8d3cf5d8" : "Batch Loaded",
+                  "f5cc2ab6-bb92-4cab-b83f-5a3d09261a41" : "Not yet assigned",
+                  "2a340d34-6b70-443a-bb1b-1b8d1c65d862" : "Other",
+                  "9634a5ab-9228-4703-baf2-4d12ebc77d56" : "Cataloged",
+                  "daf2681c-25af-4202-a3fa-e58fdf806183" : "Temporary"
+                }
+              }, {
+                "name" : "modeOfIssuanceId",
+                "enabled" : "false",
+                "required" : false,
+                "path" : "instance.modeOfIssuanceId",
+                "value" : "",
+                "subfields" : [ ]
+              }, {
+                "name" : "statisticalCodeIds",
+                "enabled" : "true",
+                "required" : false,
+                "path" : "instance.statisticalCodeIds[]",
+                "value" : "",
+                "subfields" : [ ]
+              }, {
+                "name" : "title",
+                "enabled" : "false",
+                "required" : false,
+                "path" : "instance.title",
+                "value" : "",
+                "subfields" : [ ]
+              }, {
+                "name" : "alternativeTitles",
+                "enabled" : "false",
+                "required" : false,
+                "path" : "instance.alternativeTitles[]",
+                "value" : "",
+                "subfields" : [ ]
+              }, {
+                "name" : "indexTitle",
+                "enabled" : "false",
+                "required" : false,
+                "path" : "instance.indexTitle",
+                "value" : "",
+                "subfields" : [ ]
+              }, {
+                "name" : "series",
+                "enabled" : "false",
+                "required" : false,
+                "path" : "instance.series[]",
+                "value" : "",
+                "subfields" : [ ]
+              }, {
+                "name" : "precedingTitles",
+                "enabled" : "false",
+                "required" : false,
+                "path" : "instance.precedingTitles[]",
+                "value" : "",
+                "subfields" : [ ]
+              }, {
+                "name" : "succeedingTitles",
+                "enabled" : "false",
+                "required" : false,
+                "path" : "instance.succeedingTitles[]",
+                "value" : "",
+                "subfields" : [ ]
+              }, {
+                "name" : "identifiers",
+                "enabled" : "false",
+                "required" : false,
+                "path" : "instance.identifiers[]",
+                "value" : "",
+                "subfields" : [ ]
+              }, {
+                "name" : "contributors",
+                "enabled" : "false",
+                "required" : false,
+                "path" : "instance.contributors[]",
+                "value" : "",
+                "subfields" : [ ]
+              }, {
+                "name" : "publication",
+                "enabled" : "false",
+                "required" : false,
+                "path" : "instance.publication[]",
+                "value" : "",
+                "subfields" : [ ]
+              }, {
+                "name" : "editions",
+                "enabled" : "false",
+                "required" : false,
+                "path" : "instance.editions[]",
+                "value" : "",
+                "subfields" : [ ]
+              }, {
+                "name" : "physicalDescriptions",
+                "enabled" : "false",
+                "required" : false,
+                "path" : "instance.physicalDescriptions[]",
+                "value" : "",
+                "subfields" : [ ]
+              }, {
+                "name" : "instanceTypeId",
+                "enabled" : "false",
+                "required" : false,
+                "path" : "instance.instanceTypeId",
+                "value" : "",
+                "subfields" : [ ]
+              }, {
+                "name" : "natureOfContentTermIds",
+                "enabled" : "true",
+                "required" : false,
+                "path" : "instance.natureOfContentTermIds[]",
+                "value" : "",
+                "subfields" : [ ]
+              }, {
+                "name" : "instanceFormatIds",
+                "enabled" : "false",
+                "required" : false,
+                "path" : "instance.instanceFormatIds[]",
+                "value" : "",
+                "subfields" : [ ]
+              }, {
+                "name" : "languages",
+                "enabled" : "false",
+                "required" : false,
+                "path" : "instance.languages[]",
+                "value" : "",
+                "subfields" : [ ]
+              }, {
+                "name" : "publicationFrequency",
+                "enabled" : "false",
+                "required" : false,
+                "path" : "instance.publicationFrequency[]",
+                "value" : "",
+                "subfields" : [ ]
+              }, {
+                "name" : "publicationRange",
+                "enabled" : "false",
+                "required" : false,
+                "path" : "instance.publicationRange[]",
+                "value" : "",
+                "subfields" : [ ]
+              }, {
+                "name" : "notes",
+                "enabled" : "false",
+                "required" : false,
+                "path" : "instance.notes[]",
+                "value" : "",
+                "subfields" : [ ]
+              }, {
+                "name" : "electronicAccess",
+                "enabled" : "false",
+                "required" : false,
+                "path" : "instance.electronicAccess[]",
+                "value" : "",
+                "subfields" : [ ]
+              }, {
+                "name" : "subjects",
+                "enabled" : "false",
+                "required" : false,
+                "path" : "instance.subjects[]",
+                "value" : "",
+                "subfields" : [ ]
+              }, {
+                "name" : "classifications",
+                "enabled" : "false",
+                "required" : false,
+                "path" : "instance.classifications[]",
+                "value" : "",
+                "subfields" : [ ]
+              }, {
+                "name" : "parentInstances",
+                "enabled" : "true",
+                "required" : false,
+                "path" : "instance.parentInstances[]",
+                "value" : "",
+                "subfields" : [ ]
+              }, {
+                "name" : "childInstances",
+                "enabled" : "true",
+                "required" : false,
+                "path" : "instance.childInstances[]",
+                "value" : "",
+                "subfields" : [ ]
+              } ],
+              "marcMappingDetails" : [ ]
+            },
+            "hidden" : false,
+            "metadata" : {
+              "createdDate" : "2021-04-13T14:00:00.000+00:00",
+              "createdByUserId" : "00000000-0000-0000-0000-000000000000",
+              "updatedDate" : "2021-04-13T15:00:00.462+00:00",
+              "updatedByUserId" : "00000000-0000-0000-0000-000000000000"
+            }
+          },
+          "order" : 0,
+          "childSnapshotWrappers" : [ ]
+        } ]
+      } ]
+    }, {
+      "id" : "21b390d4-d2d2-4822-b599-0adee62c678d",
+      "profileId" : "d7a0e5a9-d1be-4c31-83aa-63b848b86071",
+      "profileWrapperId" : "6fd462d4-f87a-436a-86a0-84e83f799a8a",
+      "contentType" : "MATCH_PROFILE",
+      "reactTo" : "MATCH",
+      "content" : {
+        "id" : "d7a0e5a9-d1be-4c31-83aa-63b848b86071",
+        "name" : "Match on 245$a to Instance Title",
+        "description" : "",
+        "incomingRecordType" : "MARC_BIBLIOGRAPHIC",
+        "existingRecordType" : "INSTANCE",
+        "matchDetails" : [ {
+          "incomingRecordType" : "MARC_BIBLIOGRAPHIC",
+          "existingRecordType" : "INSTANCE",
+          "incomingMatchExpression" : {
+            "dataValueType" : "VALUE_FROM_RECORD",
+            "fields" : [ {
+              "label" : "field",
+              "value" : "245"
+            }, {
+              "label" : "indicator1",
+              "value" : ""
+            }, {
+              "label" : "indicator2",
+              "value" : ""
+            }, {
+              "label" : "recordSubfield",
+              "value" : "a"
+            } ]
+          },
+          "matchCriterion" : "EXACTLY_MATCHES",
+          "existingMatchExpression" : {
+            "dataValueType" : "VALUE_FROM_RECORD",
+            "fields" : [ {
+              "label" : "field",
+              "value" : "instance.title"
+            } ]
+          }
+        } ],
+        "deleted" : false,
+        "userInfo" : {
+          "firstName" : "",
+          "lastName" : "Superuser",
+          "userName" : "diku_admin"
+        },
+        "parentProfiles" : [ ],
+        "childProfiles" : [ ],
+        "hidden" : false,
+        "metadata" : {
+          "createdDate" : "2024-05-15T15:49:17.143+00:00",
+          "createdByUserId" : "8ca8e682-af58-40f8-b969-4a133c8a085c",
+          "updatedDate" : "2024-05-15T21:10:31.320+00:00",
+          "updatedByUserId" : "8ca8e682-af58-40f8-b969-4a133c8a085c"
+        }
+      },
+      "order" : 0,
+      "childSnapshotWrappers" : [ {
+        "id" : "006ea283-6cb0-45bb-b014-e16c72093b8c",
+        "profileId" : "a222984f-546f-45c3-8a37-20c0fbf93365",
+        "profileWrapperId" : "4b9075dc-0b40-4b51-a0af-95cea367af05",
+        "contentType" : "MATCH_PROFILE",
+        "reactTo" : "NON_MATCH",
+        "content" : {
+          "id" : "a222984f-546f-45c3-8a37-20c0fbf93365",
+          "name" : "Match on 856.4.0$u to Holdings electronic access URI",
+          "description" : "",
+          "incomingRecordType" : "MARC_BIBLIOGRAPHIC",
+          "existingRecordType" : "HOLDINGS",
+          "matchDetails" : [ {
+            "incomingRecordType" : "MARC_BIBLIOGRAPHIC",
+            "existingRecordType" : "HOLDINGS",
+            "incomingMatchExpression" : {
+              "dataValueType" : "VALUE_FROM_RECORD",
+              "fields" : [ {
+                "label" : "field",
+                "value" : "856"
+              }, {
+                "label" : "indicator1",
+                "value" : "4"
+              }, {
+                "label" : "indicator2",
+                "value" : "0"
+              }, {
+                "label" : "recordSubfield",
+                "value" : "u"
+              } ]
+            },
+            "matchCriterion" : "EXACTLY_MATCHES",
+            "existingMatchExpression" : {
+              "dataValueType" : "VALUE_FROM_RECORD",
+              "fields" : [ {
+                "label" : "field",
+                "value" : "holdingsrecord.electronicAccess[].uri"
+              } ]
+            }
+          } ],
+          "deleted" : false,
+          "userInfo" : {
+            "firstName" : "",
+            "lastName" : "Superuser",
+            "userName" : "diku_admin"
+          },
+          "parentProfiles" : [ ],
+          "childProfiles" : [ ],
+          "hidden" : false,
+          "metadata" : {
+            "createdDate" : "2024-05-15T15:41:34.118+00:00",
+            "createdByUserId" : "8ca8e682-af58-40f8-b969-4a133c8a085c",
+            "updatedDate" : "2024-05-15T21:13:16.778+00:00",
+            "updatedByUserId" : "8ca8e682-af58-40f8-b969-4a133c8a085c"
+          }
+        },
+        "order" : 0,
+        "childSnapshotWrappers" : [ {
+          "id" : "375bb7b1-71ba-4bd2-88fb-324cf29d7d7f",
+          "profileId" : "b822339d-bae5-48e0-948b-7f7aee5ea545",
+          "profileWrapperId" : "9fbc6e93-1166-45c8-a3c0-a02c3e17a5a2",
+          "contentType" : "ACTION_PROFILE",
+          "reactTo" : "MATCH",
+          "content" : {
+            "id" : "b822339d-bae5-48e0-948b-7f7aee5ea545",
+            "name" : "Update Holdings",
+            "description" : "",
+            "action" : "UPDATE",
+            "folioRecord" : "HOLDINGS",
+            "deleted" : false,
+            "userInfo" : {
+              "firstName" : "",
+              "lastName" : "Superuser",
+              "userName" : "diku_admin"
+            },
+            "parentProfiles" : [ ],
+            "childProfiles" : [ ],
+            "hidden" : false,
+            "remove9Subfields" : false,
+            "metadata" : {
+              "createdDate" : "2024-05-15T15:43:48.462+00:00",
+              "createdByUserId" : "8ca8e682-af58-40f8-b969-4a133c8a085c",
+              "updatedDate" : "2024-05-15T15:43:48.462+00:00",
+              "updatedByUserId" : "8ca8e682-af58-40f8-b969-4a133c8a085c"
+            }
+          },
+          "order" : 0,
+          "childSnapshotWrappers" : [ {
+            "id" : "8ed00123-6bae-4d2a-b5f3-e3f3a7e21fad",
+            "profileId" : "08ec0c02-e52d-43c4-91f7-209bd56e7688",
+            "profileWrapperId" : "30eeae29-a1bf-40d8-bd97-f6e00aa2b02f",
+            "contentType" : "MAPPING_PROFILE",
+            "content" : {
+              "id" : "08ec0c02-e52d-43c4-91f7-209bd56e7688",
+              "name" : "Holdings Mapping profile FAT-937",
+              "description" : "",
+              "incomingRecordType" : "MARC_BIBLIOGRAPHIC",
+              "existingRecordType" : "HOLDINGS",
+              "deleted" : false,
+              "userInfo" : {
+                "firstName" : "",
+                "lastName" : "Superuser",
+                "userName" : "diku_admin"
+              },
+              "marcFieldProtectionSettings" : [ ],
+              "parentProfiles" : [ ],
+              "childProfiles" : [ ],
+              "mappingDetails" : {
+                "name" : "holdings",
+                "recordType" : "HOLDINGS",
+                "mappingFields" : [ {
+                  "name" : "holdingsTypeId",
+                  "enabled" : "true",
+                  "required" : false,
+                  "path" : "holdings.holdingsTypeId",
+                  "value" : "\"Electronic\"",
+                  "subfields" : [ ],
+                  "acceptedValues" : {
+                    "996f93e2-5b5e-4cf2-9168-33ced1f95eed" : "Electronic"
+                  }
+                }, {
+                  "name" : "permanentLocationId",
+                  "enabled" : "true",
+                  "required" : false,
+                  "path" : "holdings.permanentLocationId",
+                  "value" : "\"Online (E)\"",
+                  "subfields" : [ ],
+                  "acceptedValues" : {
+                    "184aae84-a5bf-4c6a-85ba-4a7c73026cd5" : "Online (E)",
+                    "fcd64ce1-6995-48f0-840e-89ffa2288371" : "Main Library (KU/CC/DI/M)",
+                    "53cf956f-c1df-410b-8bea-27f712cca7c0" : "Annex (KU/CC/DI/A)"
+                  }
+                }, {
+                  "name" : "callNumberTypeId",
+                  "enabled" : "true",
+                  "required" : false,
+                  "path" : "holdings.callNumberTypeId",
+                  "value" : "\"Library of Congress classification\"",
+                  "subfields" : [ ],
+                  "acceptedValues" : {
+                    "512173a7-bd09-490e-b773-17d83f2b63fe" : "LC Modified",
+                    "95467209-6d7b-468b-94df-0f5d7ad2747d" : "Library of Congress classification"
+                  }
+                }, {
+                  "name" : "callNumber",
+                  "enabled" : "true",
+                  "required" : false,
+                  "path" : "holdings.callNumber",
+                  "value" : "050$a \" \" 050$b",
+                  "subfields" : [ ]
+                }, {
+                  "name" : "electronicAccess",
+                  "enabled" : "true",
+                  "required" : false,
+                  "path" : "holdings.electronicAccess[]",
+                  "value" : "",
+                  "repeatableFieldAction" : "EXTEND_EXISTING",
+                  "subfields" : [ {
+                    "order" : 0,
+                    "path" : "holdings.electronicAccess[]",
+                    "fields" : [ {
+                      "name" : "relationshipId",
+                      "enabled" : "true",
+                      "required" : false,
+                      "path" : "holdings.electronicAccess[].relationshipId",
+                      "value" : "\"Resource\"",
+                      "subfields" : [ ],
+                      "acceptedValues" : {
+                        "3b430592-2e09-4b48-9a0c-0636d66b9fb3" : "Version of resource",
+                        "f5d0068e-6272-458e-8a81-b85e7b9a14aa" : "Resource"
+                      }
+                    }, {
+                      "name" : "uri",
+                      "enabled" : "true",
+                      "required" : false,
+                      "path" : "holdings.electronicAccess[].uri",
+                      "value" : "856$u",
+                      "subfields" : [ ]
+                    }, {
+                      "name" : "linkText",
+                      "enabled" : "true",
+                      "required" : false,
+                      "path" : "holdings.electronicAccess[].linkText",
+                      "value" : "",
+                      "subfields" : [ ]
+                    }, {
+                      "name" : "materialsSpecification",
+                      "enabled" : "true",
+                      "required" : false,
+                      "path" : "holdings.electronicAccess[].materialsSpecification",
+                      "value" : "",
+                      "subfields" : [ ]
+                    }, {
+                      "name" : "publicNote",
+                      "enabled" : "true",
+                      "required" : false,
+                      "path" : "holdings.electronicAccess[].publicNote",
+                      "value" : "",
+                      "subfields" : [ ]
+                    } ]
+                  } ]
+                } ],
+                "marcMappingDetails" : [ ]
+              },
+              "hidden" : false,
+              "metadata" : {
+                "createdDate" : "2024-05-14T17:45:54.686+00:00",
+                "createdByUserId" : "8ca8e682-af58-40f8-b969-4a133c8a085c",
+                "updatedDate" : "2024-05-14T17:45:54.686+00:00",
+                "updatedByUserId" : "8ca8e682-af58-40f8-b969-4a133c8a085c"
+              }
+            },
+            "order" : 0,
+            "childSnapshotWrappers" : [ ]
+          } ]
+        }, {
+          "id" : "a9026590-1ef5-4372-a8b6-34ccc0aa3986",
+          "profileId" : "4eacd228-77a5-4343-868b-8a7c1ccde79e",
+          "profileWrapperId" : "c7d5295c-1d80-4a70-a272-ed61e647845c",
+          "contentType" : "ACTION_PROFILE",
+          "reactTo" : "NON_MATCH",
+          "content" : {
+            "id" : "4eacd228-77a5-4343-868b-8a7c1ccde79e",
+            "name" : "Update Instance",
+            "description" : "",
+            "action" : "UPDATE",
+            "folioRecord" : "INSTANCE",
+            "deleted" : false,
+            "userInfo" : {
+              "firstName" : "",
+              "lastName" : "Superuser",
+              "userName" : "diku_admin"
+            },
+            "parentProfiles" : [ ],
+            "childProfiles" : [ ],
+            "hidden" : false,
+            "remove9Subfields" : true,
+            "metadata" : {
+              "createdDate" : "2024-05-14T18:06:48.907+00:00",
+              "createdByUserId" : "8ca8e682-af58-40f8-b969-4a133c8a085c",
+              "updatedDate" : "2024-05-15T15:42:35.748+00:00",
+              "updatedByUserId" : "8ca8e682-af58-40f8-b969-4a133c8a085c"
+            }
+          },
+          "order" : 0,
+          "childSnapshotWrappers" : [ {
+            "id" : "bbde2fa6-a40c-4c87-9351-ee6e40742f57",
+            "profileId" : "bf7b3b86-9b84-11eb-a8b3-0242ac130003",
+            "profileWrapperId" : "cc424faf-2473-47e5-979a-5f4a90f67adf",
+            "contentType" : "MAPPING_PROFILE",
+            "content" : {
+              "id" : "bf7b3b86-9b84-11eb-a8b3-0242ac130003",
+              "name" : "Default - Create instance",
+              "description" : "This field mapping profile is used with FOLIO's default job profile for creating Inventory Instances and SRS MARC Bibliographic records. It can be edited, duplicated, deleted, or linked to additional action profiles.",
+              "incomingRecordType" : "MARC_BIBLIOGRAPHIC",
+              "existingRecordType" : "INSTANCE",
+              "deleted" : false,
+              "userInfo" : {
+                "firstName" : "System",
+                "lastName" : "System",
+                "userName" : "System"
+              },
+              "marcFieldProtectionSettings" : [ ],
+              "parentProfiles" : [ ],
+              "childProfiles" : [ ],
+              "mappingDetails" : {
+                "name" : "instance",
+                "recordType" : "INSTANCE",
+                "mappingFields" : [ {
+                  "name" : "discoverySuppress",
+                  "enabled" : "true",
+                  "required" : false,
+                  "path" : "instance.discoverySuppress",
+                  "value" : "",
+                  "subfields" : [ ]
+                }, {
+                  "name" : "staffSuppress",
+                  "enabled" : "true",
+                  "required" : false,
+                  "path" : "instance.staffSuppress",
+                  "value" : "",
+                  "subfields" : [ ]
+                }, {
+                  "name" : "previouslyHeld",
+                  "enabled" : "true",
+                  "required" : false,
+                  "path" : "instance.previouslyHeld",
+                  "value" : "",
+                  "subfields" : [ ]
+                }, {
+                  "name" : "hrid",
+                  "enabled" : "false",
+                  "required" : false,
+                  "path" : "instance.hrid",
+                  "value" : "",
+                  "subfields" : [ ]
+                }, {
+                  "name" : "source",
+                  "enabled" : "false",
+                  "required" : false,
+                  "path" : "instance.source",
+                  "value" : "",
+                  "subfields" : [ ]
+                }, {
+                  "name" : "catalogedDate",
+                  "enabled" : "true",
+                  "required" : false,
+                  "path" : "instance.catalogedDate",
+                  "value" : "",
+                  "subfields" : [ ]
+                }, {
+                  "name" : "statusId",
+                  "enabled" : "true",
+                  "required" : false,
+                  "path" : "instance.statusId",
+                  "value" : "",
+                  "subfields" : [ ],
+                  "acceptedValues" : {
+                    "26f5208e-110a-4394-be29-1569a8c84a65" : "Uncataloged",
+                    "52a2ff34-2a12-420d-8539-21aa8d3cf5d8" : "Batch Loaded",
+                    "f5cc2ab6-bb92-4cab-b83f-5a3d09261a41" : "Not yet assigned",
+                    "2a340d34-6b70-443a-bb1b-1b8d1c65d862" : "Other",
+                    "9634a5ab-9228-4703-baf2-4d12ebc77d56" : "Cataloged",
+                    "daf2681c-25af-4202-a3fa-e58fdf806183" : "Temporary"
+                  }
+                }, {
+                  "name" : "modeOfIssuanceId",
+                  "enabled" : "false",
+                  "required" : false,
+                  "path" : "instance.modeOfIssuanceId",
+                  "value" : "",
+                  "subfields" : [ ]
+                }, {
+                  "name" : "statisticalCodeIds",
+                  "enabled" : "true",
+                  "required" : false,
+                  "path" : "instance.statisticalCodeIds[]",
+                  "value" : "",
+                  "subfields" : [ ]
+                }, {
+                  "name" : "title",
+                  "enabled" : "false",
+                  "required" : false,
+                  "path" : "instance.title",
+                  "value" : "",
+                  "subfields" : [ ]
+                }, {
+                  "name" : "alternativeTitles",
+                  "enabled" : "false",
+                  "required" : false,
+                  "path" : "instance.alternativeTitles[]",
+                  "value" : "",
+                  "subfields" : [ ]
+                }, {
+                  "name" : "indexTitle",
+                  "enabled" : "false",
+                  "required" : false,
+                  "path" : "instance.indexTitle",
+                  "value" : "",
+                  "subfields" : [ ]
+                }, {
+                  "name" : "series",
+                  "enabled" : "false",
+                  "required" : false,
+                  "path" : "instance.series[]",
+                  "value" : "",
+                  "subfields" : [ ]
+                }, {
+                  "name" : "precedingTitles",
+                  "enabled" : "false",
+                  "required" : false,
+                  "path" : "instance.precedingTitles[]",
+                  "value" : "",
+                  "subfields" : [ ]
+                }, {
+                  "name" : "succeedingTitles",
+                  "enabled" : "false",
+                  "required" : false,
+                  "path" : "instance.succeedingTitles[]",
+                  "value" : "",
+                  "subfields" : [ ]
+                }, {
+                  "name" : "identifiers",
+                  "enabled" : "false",
+                  "required" : false,
+                  "path" : "instance.identifiers[]",
+                  "value" : "",
+                  "subfields" : [ ]
+                }, {
+                  "name" : "contributors",
+                  "enabled" : "false",
+                  "required" : false,
+                  "path" : "instance.contributors[]",
+                  "value" : "",
+                  "subfields" : [ ]
+                }, {
+                  "name" : "publication",
+                  "enabled" : "false",
+                  "required" : false,
+                  "path" : "instance.publication[]",
+                  "value" : "",
+                  "subfields" : [ ]
+                }, {
+                  "name" : "editions",
+                  "enabled" : "false",
+                  "required" : false,
+                  "path" : "instance.editions[]",
+                  "value" : "",
+                  "subfields" : [ ]
+                }, {
+                  "name" : "physicalDescriptions",
+                  "enabled" : "false",
+                  "required" : false,
+                  "path" : "instance.physicalDescriptions[]",
+                  "value" : "",
+                  "subfields" : [ ]
+                }, {
+                  "name" : "instanceTypeId",
+                  "enabled" : "false",
+                  "required" : false,
+                  "path" : "instance.instanceTypeId",
+                  "value" : "",
+                  "subfields" : [ ]
+                }, {
+                  "name" : "natureOfContentTermIds",
+                  "enabled" : "true",
+                  "required" : false,
+                  "path" : "instance.natureOfContentTermIds[]",
+                  "value" : "",
+                  "subfields" : [ ]
+                }, {
+                  "name" : "instanceFormatIds",
+                  "enabled" : "false",
+                  "required" : false,
+                  "path" : "instance.instanceFormatIds[]",
+                  "value" : "",
+                  "subfields" : [ ]
+                }, {
+                  "name" : "languages",
+                  "enabled" : "false",
+                  "required" : false,
+                  "path" : "instance.languages[]",
+                  "value" : "",
+                  "subfields" : [ ]
+                }, {
+                  "name" : "publicationFrequency",
+                  "enabled" : "false",
+                  "required" : false,
+                  "path" : "instance.publicationFrequency[]",
+                  "value" : "",
+                  "subfields" : [ ]
+                }, {
+                  "name" : "publicationRange",
+                  "enabled" : "false",
+                  "required" : false,
+                  "path" : "instance.publicationRange[]",
+                  "value" : "",
+                  "subfields" : [ ]
+                }, {
+                  "name" : "notes",
+                  "enabled" : "false",
+                  "required" : false,
+                  "path" : "instance.notes[]",
+                  "value" : "",
+                  "subfields" : [ ]
+                }, {
+                  "name" : "electronicAccess",
+                  "enabled" : "false",
+                  "required" : false,
+                  "path" : "instance.electronicAccess[]",
+                  "value" : "",
+                  "subfields" : [ ]
+                }, {
+                  "name" : "subjects",
+                  "enabled" : "false",
+                  "required" : false,
+                  "path" : "instance.subjects[]",
+                  "value" : "",
+                  "subfields" : [ ]
+                }, {
+                  "name" : "classifications",
+                  "enabled" : "false",
+                  "required" : false,
+                  "path" : "instance.classifications[]",
+                  "value" : "",
+                  "subfields" : [ ]
+                }, {
+                  "name" : "parentInstances",
+                  "enabled" : "true",
+                  "required" : false,
+                  "path" : "instance.parentInstances[]",
+                  "value" : "",
+                  "subfields" : [ ]
+                }, {
+                  "name" : "childInstances",
+                  "enabled" : "true",
+                  "required" : false,
+                  "path" : "instance.childInstances[]",
+                  "value" : "",
+                  "subfields" : [ ]
+                } ],
+                "marcMappingDetails" : [ ]
+              },
+              "hidden" : false,
+              "metadata" : {
+                "createdDate" : "2021-04-13T14:00:00.000+00:00",
+                "createdByUserId" : "00000000-0000-0000-0000-000000000000",
+                "updatedDate" : "2021-04-13T15:00:00.462+00:00",
+                "updatedByUserId" : "00000000-0000-0000-0000-000000000000"
+              }
+            },
+            "order" : 0,
+            "childSnapshotWrappers" : [ ]
+          } ]
+        }, {
+          "id" : "997b3d1e-6556-44d5-a4c0-c04dbecefa98",
+          "profileId" : "360a74a0-787b-4797-b86a-be82e1012911",
+          "profileWrapperId" : "2f6a8a1f-c968-4e9c-b4d6-95c2fbeff3e6",
+          "contentType" : "ACTION_PROFILE",
+          "reactTo" : "MATCH",
+          "content" : {
+            "id" : "360a74a0-787b-4797-b86a-be82e1012911",
+            "name" : "ITEM action profile for FAT-937",
+            "description" : "ITEM action profile for FAT-937",
+            "action" : "CREATE",
+            "folioRecord" : "ITEM",
+            "deleted" : false,
+            "userInfo" : {
+              "firstName" : "",
+              "lastName" : "Superuser",
+              "userName" : "diku_admin"
+            },
+            "parentProfiles" : [ ],
+            "childProfiles" : [ ],
+            "hidden" : false,
+            "remove9Subfields" : false,
+            "metadata" : {
+              "createdDate" : "2024-05-14T17:45:54.984+00:00",
+              "createdByUserId" : "8ca8e682-af58-40f8-b969-4a133c8a085c",
+              "updatedDate" : "2024-05-14T17:45:54.984+00:00",
+              "updatedByUserId" : "8ca8e682-af58-40f8-b969-4a133c8a085c"
+            }
+          },
+          "order" : 1,
+          "childSnapshotWrappers" : [ {
+            "id" : "f8a7d919-557b-49c7-91aa-f075bc206309",
+            "profileId" : "d87eac3e-fd3f-4928-b57d-63849fe07193",
+            "profileWrapperId" : "4581794d-7b8e-47a5-b0ca-07878008b202",
+            "contentType" : "MAPPING_PROFILE",
+            "content" : {
+              "id" : "d87eac3e-fd3f-4928-b57d-63849fe07193",
+              "name" : "Item Mapping profile FAT-937",
+              "description" : "",
+              "incomingRecordType" : "MARC_BIBLIOGRAPHIC",
+              "existingRecordType" : "ITEM",
+              "deleted" : false,
+              "userInfo" : {
+                "firstName" : "",
+                "lastName" : "Superuser",
+                "userName" : "diku_admin"
+              },
+              "marcFieldProtectionSettings" : [ ],
+              "parentProfiles" : [ ],
+              "childProfiles" : [ ],
+              "mappingDetails" : {
+                "name" : "item",
+                "recordType" : "ITEM",
+                "mappingFields" : [ {
+                  "name" : "materialType.id",
+                  "enabled" : "true",
+                  "required" : false,
+                  "path" : "item.materialType.id",
+                  "value" : "\"electronic resource\"",
+                  "subfields" : [ ],
+                  "acceptedValues" : {
+                    "1a54b431-2e4f-452d-9cae-9cee66c9a892" : "book",
+                    "615b8413-82d5-4203-aa6e-e37984cb5ac3" : "electronic resource"
+                  }
+                }, {
+                  "name" : "notes",
+                  "enabled" : "true",
+                  "required" : false,
+                  "path" : "item.notes[]",
+                  "value" : "",
+                  "repeatableFieldAction" : "EXTEND_EXISTING",
+                  "subfields" : [ {
+                    "order" : 0,
+                    "path" : "item.notes[]",
+                    "fields" : [ {
+                      "name" : "itemNoteTypeId",
+                      "enabled" : "true",
+                      "required" : false,
+                      "path" : "item.notes[].itemNoteTypeId",
+                      "value" : "\"Electronic bookplate\"",
+                      "subfields" : [ ],
+                      "acceptedValues" : {
+                        "0e40884c-3523-4c6d-8187-d578e3d2794e" : "Action note",
+                        "f3ae3823-d096-4c65-8734-0c1efd2ffea8" : "Electronic bookplate"
+                      }
+                    }, {
+                      "name" : "note",
+                      "enabled" : "true",
+                      "required" : false,
+                      "path" : "item.notes[].note",
+                      "value" : "\"Smith Family Foundation\"",
+                      "subfields" : [ ]
+                    }, {
+                      "name" : "staffOnly",
+                      "enabled" : "true",
+                      "required" : false,
+                      "path" : "item.notes[].staffOnly",
+                      "booleanFieldAction" : "ALL_TRUE",
+                      "subfields" : [ ]
+                    } ]
+                  } ]
+                }, {
+                  "name" : "permanentLoanType.id",
+                  "enabled" : "true",
+                  "required" : false,
+                  "path" : "item.permanentLoanType.id",
+                  "value" : "\"Can circulate\"",
+                  "subfields" : [ ],
+                  "acceptedValues" : {
+                    "2b94c631-fca9-4892-a730-03ee529ffe27" : "Can circulate",
+                    "a1dc1ce3-d56f-4d8a-b498-d5d674ccc845" : "Selected"
+                  }
+                }, {
+                  "name" : "status.name",
+                  "enabled" : "true",
+                  "required" : false,
+                  "path" : "item.status.name",
+                  "value" : "\"Available\"",
+                  "subfields" : [ ]
+                } ],
+                "marcMappingDetails" : [ ]
+              },
+              "hidden" : false,
+              "metadata" : {
+                "createdDate" : "2024-05-14T17:45:54.890+00:00",
+                "createdByUserId" : "8ca8e682-af58-40f8-b969-4a133c8a085c",
+                "updatedDate" : "2024-05-14T17:45:54.890+00:00",
+                "updatedByUserId" : "8ca8e682-af58-40f8-b969-4a133c8a085c"
+              }
+            },
+            "order" : 0,
+            "childSnapshotWrappers" : [ ]
+          } ]
+        } ]
+      } ]
+    } ]
+  } ]
+}

--- a/job-profile-wrangler/src/test/resources/source_record_response.json
+++ b/job-profile-wrangler/src/test/resources/source_record_response.json
@@ -1,0 +1,81 @@
+{
+  "id": "0440f570-d30f-4fab-a80e-e81b13b68b2c",
+  "snapshotId": "c171a322-14d9-4719-9519-962c9a8b8f4c",
+  "matchedId": "0440f570-d30f-4fab-a80e-e81b13b68b2c",
+  "generation": 0,
+  "recordType": "MARC_BIB",
+  "rawRecord": {
+    "id": "0440f570-d30f-4fab-a80e-e81b13b68b2c",
+    "content": "00161nam a2200061 a 4500008002600000245004400026856002900070\u001e160630u16421756ugi 0 a0wd\u001e  \u001faThe Heart Is Deceitful Above All Things\u001e40\u001fuwww.regenia-stanton.name\u001e\u001d"
+  },
+  "parsedRecord": {
+    "id": "0440f570-d30f-4fab-a80e-e81b13b68b2c",
+    "content": {
+      "fields": [
+        {
+          "001": "in00000000011"
+        },
+        {
+          "005": "20240514175556.3"
+        },
+        {
+          "008": "160630u16421756ugi 0 a0wd"
+        },
+        {
+          "245": {
+            "ind1": " ",
+            "ind2": " ",
+            "subfields": [
+              {
+                "a": "The Heart Is Deceitful Above All Things"
+              }
+            ]
+          }
+        },
+        {
+          "856": {
+            "ind1": "4",
+            "ind2": "0",
+            "subfields": [
+              {
+                "u": "www.regenia-stanton.name"
+              }
+            ]
+          }
+        },
+        {
+          "999": {
+            "ind1": "f",
+            "ind2": "f",
+            "subfields": [
+              {
+                "i": "7e2ad1dc-1f3b-4133-a975-2b08411b26c6"
+              },
+              {
+                "s": "0440f570-d30f-4fab-a80e-e81b13b68b2c"
+              }
+            ]
+          }
+        }
+      ],
+      "leader": "00307nam a2200097 a 4500"
+    }
+  },
+  "deleted": false,
+  "order": 0,
+  "externalIdsHolder": {
+    "instanceId": "7e2ad1dc-1f3b-4133-a975-2b08411b26c6",
+    "instanceHrid": "in00000000011"
+  },
+  "additionalInfo": {
+    "suppressDiscovery": false
+  },
+  "state": "OLD",
+  "leaderRecordStatus": "n",
+  "metadata": {
+    "createdDate": "2024-05-14T17:55:56.407+00:00",
+    "createdByUserId": "8ca8e682-af58-40f8-b969-4a133c8a085c",
+    "updatedDate": "2024-05-14T19:09:51.597+00:00",
+    "updatedByUserId": "8ca8e682-af58-40f8-b969-4a133c8a085c"
+  }
+}


### PR DESCRIPTION
## Purpose
First pass on creating a record with a job profile as a target

## Approach
Using existing objects as template, new objects are created that will exercise all branches of a job profile decision tree. The job profile is converted to a graph, then paths from the job profile node to the leaf nodes(action/mapping profiles) is calculated. Each path is used to create a record, ensuring that record can walk through the path from end to end. Records are modified to satisfy match profiles.

There are more functionality that could be put in place. This is the first iteration. The goal is to have a repository of job profiles collected from many libraries, and be able to create records to exercise each job profile as part of periodic testing.

