### PR TITLE
[MODDICONV-390] Move data import profile validation to service layer

### DIFF
--- a/mod-di-converter-storage-server/src/main/java/org/folio/rest/impl/DataImportProfilesImpl.java
+++ b/mod-di-converter-storage-server/src/main/java/org/folio/rest/impl/DataImportProfilesImpl.java
@@ -357,7 +357,7 @@ public class DataImportProfilesImpl implements DataImportProfiles {
                                                    Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {
       try {
-
+        entity.getProfile().setMetadata(getMetadata(okapiHeaders));
         actionProfileService.saveProfile(entity, new OkapiConnectionParams(okapiHeaders))
           .map(profile -> (Response) PostDataImportProfilesActionProfilesResponse
             .respond201WithApplicationJson(entity.withProfile(profile).withId(profile.getId()), PostDataImportProfilesActionProfilesResponse.headersFor201()))

--- a/mod-di-converter-storage-server/src/main/java/org/folio/rest/impl/DataImportProfilesImpl.java
+++ b/mod-di-converter-storage-server/src/main/java/org/folio/rest/impl/DataImportProfilesImpl.java
@@ -4,38 +4,27 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
-import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
-import io.vertx.core.impl.future.CompositeFutureImpl;
 import io.vertx.core.json.JsonObject;
 
-import io.vertx.core.json.jackson.DatabindCodec;
-import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.folio.okapi.common.GenericCompositeFuture;
 import org.folio.rest.impl.util.ExceptionHelper;
 import org.folio.rest.impl.util.OkapiConnectionParams;
 import org.folio.rest.jaxrs.model.ActionProfile;
 import org.folio.rest.jaxrs.model.ActionProfileCollection;
 import org.folio.rest.jaxrs.model.ActionProfileUpdateDto;
-import org.folio.rest.jaxrs.model.Error;
-import org.folio.rest.jaxrs.model.Errors;
 import org.folio.rest.jaxrs.model.JobProfile;
 import org.folio.rest.jaxrs.model.JobProfileCollection;
 import org.folio.rest.jaxrs.model.JobProfileUpdateDto;
 import org.folio.rest.jaxrs.model.MappingProfile;
 import org.folio.rest.jaxrs.model.MappingProfileCollection;
 import org.folio.rest.jaxrs.model.MappingProfileUpdateDto;
-import org.folio.rest.jaxrs.model.MappingRule;
-import org.folio.rest.jaxrs.model.MappingDetail;
 import org.folio.rest.jaxrs.model.MatchProfile;
 import org.folio.rest.jaxrs.model.MatchProfileCollection;
 import org.folio.rest.jaxrs.model.MatchProfileUpdateDto;
 import org.folio.rest.jaxrs.model.Metadata;
 import org.folio.rest.jaxrs.model.ProfileType;
-import org.folio.rest.jaxrs.model.OperationType;
 import org.folio.rest.jaxrs.model.ProfileAssociation;
 import org.folio.rest.jaxrs.resource.DataImportProfiles;
 import org.folio.rest.tools.utils.TenantTool;
@@ -49,96 +38,20 @@ import javax.ws.rs.BadRequestException;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.core.Response;
 import java.nio.charset.StandardCharsets;
-import java.util.Optional;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Date;
-import java.util.LinkedHashMap;
-import java.util.LinkedList;
-import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.stream.Collectors;
 
 import static java.lang.String.format;
 import static org.folio.rest.RestVerticle.OKAPI_HEADER_TOKEN;
 import static org.folio.rest.RestVerticle.OKAPI_USERID_HEADER;
-import static org.folio.rest.jaxrs.model.ProfileType.ACTION_PROFILE;
 
 public class DataImportProfilesImpl implements DataImportProfiles {
 
   private static final Logger logger = LogManager.getLogger();
-  private static final String DUPLICATE_PROFILE_ERROR_CODE = "%s '%s' already exists";
-  private static final String DUPLICATE_PROFILE_ID_ERROR_CODE = "%s with id '%s' already exists";
-  private static final String NOT_EMPTY_RELATED_PROFILE_ERROR_CODE = "%s read-only '%s' field should be empty";
-  private static final String PROFILE_VALIDATE_ERROR_MESSAGE = "Failed to validate %s";
   private static final String MASTER_PROFILE_NOT_FOUND_MSG = "Master profile with id '%s' was not found";
   private static final String DETAIL_PROFILE_NOT_FOUND_MSG = "Detail profile with id '%s' was not found";
-  private static final String INVALID_REPEATABLE_FIELD_ACTION_FOR_EMPTY_SUBFIELDS_MESSAGE = "Invalid repeatableFieldAction for empty subfields: %s";
-  private static final String INVALID_RECORD_TYPE_LINKED_MAPPING_PROFILE_TO_ACTION_PROFILE = "Mapping profile '%s' can not be linked to this Action profile. ExistingRecordType and FolioRecord types are different";
-  private static final String INVALID_RECORD_TYPE_LINKED_ACTION_PROFILE_TO_MAPPING_PROFILE = "Action profile '%s' can not be linked to this Mapping profile. FolioRecord and ExistingRecordType types are different";
-  private static final String INVALID_MAPPING_PROFILE_NEW_RECORD_TYPE_LINKED_TO_ACTION_PROFILE = "Can not update MappingProfile recordType and linked ActionProfile recordType are different";
-  private static final String INVALID_ACTION_PROFILE_NEW_RECORD_TYPE_LINKED_TO_MAPPING_PROFILE = "Can not update ActionProfile recordType and linked MappingProfile recordType are different";
-  private static final String INVALID_ACTION_TYPE_LINKED_ACTION_PROFILE_TO_MAPPING_PROFILE = "Unable to complete requested change. " +
-    "MARC Update Action profiles can only be linked with MARC Update Mapping profiles and MARC Modify Action profiles can only be linked with MARC Modify Mapping profiles. " +
-    "Please ensure your Action and Mapping profiles are of like types and try again.";
-  private static final String INVALID_ACTION_PROFILE_ACTION_TYPE = "Can't create ActionProfile for MARC Bib record type with Create action";
-
-  static final Map<String, String> ERROR_CODES_TYPES_RELATION = Map.of(
-    "mappingProfile", "The field mapping profile",
-    "jobProfile", "Job profile",
-    "matchProfile", "Match profile",
-    "actionProfile", "Action profile"
-  );
-
-  private static final String[] MATCH_PROFILES = {
-    "d27d71ce-8a1e-44c6-acea-96961b5592c6", //OCLC_MARC_MARC_MATCH_PROFILE_ID
-    "31dbb554-0826-48ec-a0a4-3c55293d4dee", //OCLC_INSTANCE_UUID_MATCH_PROFILE_ID
-    "4be5d1d2-1f5a-42ff-a9bd-fc90609d94b6",  //DEFAULT_DELETE_MARC_AUTHORITY_MATCH_PROFILE_ID
-    "91cec42a-260d-4a8c-a9fb-90d9435ca2f4", //DEFAULT_QM_MARC_BIB_UPDATE_MATCH_PROFILE_ID
-    "2a599369-817f-4fe8-bae2-f3e3987990fe", //DEFAULT_QM_HOLDINGS_UPDATE_MATCH_PROFILE_ID
-    "aff72eae-847c-4a97-b7b9-c1ddb8cdcbbf"  //DEFAULT_QM_AUTHORITY_UPDATE_MATCH_PROFILE_ID
-  };
-  private static final String[] JOB_PROFILES = {
-    "d0ebb7b0-2f0f-11eb-adc1-0242ac120002", //OCLC_CREATE_INSTANCE_JOB_PROFILE_ID,
-    "91f9b8d6-d80e-4727-9783-73fb53e3c786", //OCLC_UPDATE_INSTANCE_JOB_PROFILE_ID,
-    "fa0262c7-5816-48d0-b9b3-7b7a862a5bc7", //DEFAULT_CREATE_DERIVE_HOLDINGS_JOB_PROFILE_ID
-    "6409dcff-71fa-433a-bc6a-e70ad38a9604", //DEFAULT_CREATE_DERIVE_INSTANCE_JOB_PROFILE_ID
-    "80898dee-449f-44dd-9c8e-37d5eb469b1d", //DEFAULT_CREATE_HOLDINGS_AND_SRS_MARC_HOLDINGS_JOB_PROFILE_ID
-    "1a338fcd-3efc-4a03-b007-394eeb0d5fb9", //DEFAULT_DELETE_MARC_AUTHORITY_JOB_PROFILE_ID
-    "cf6f2718-5aa5-482a-bba5-5bc9b75614da", //DEFAULT_QM_MARC_BIB_UPDATE_JOB_PROFILE_ID
-    "6cb347c6-c0b0-4363-89fc-32cedede87ba", //DEFAULT_QM_HOLDINGS_UPDATE_JOB_PROFILE_ID
-    "c7fcbc40-c4c0-411d-b569-1fc6bc142a92",
-    "6eefa4c6-bbf7-4845-ad82-de7fc4abd0e3"//DEFAULT_QM_AUTHORITY_CREATE_JOB_PROFILE_ID
-  };
-  private static final String[] MAPPING_PROFILES = {
-    "d0ebbc2e-2f0f-11eb-adc1-0242ac120002", //OCLC_CREATE_MAPPING_PROFILE_ID
-    "862000b9-84ea-4cae-a223-5fc0552f2b42", //OCLC_UPDATE_MAPPING_PROFILE_ID
-    "f90864ef-8030-480f-a43f-8cdd21233252", //OCLC_UPDATE_MARC_BIB_MAPPING_PROFILE_ID
-    "991c0300-44a6-47e3-8ea2-b01bb56a38cc", //DEFAULT_CREATE_DERIVE_INSTANCE_MAPPING_PROFILE_ID
-    "e0fbaad5-10c0-40d5-9228-498b351dbbaa", //DEFAULT_CREATE_DERIVE_HOLDINGS_MAPPING_PROFILE_ID
-    "13cf7adf-c7a7-4c2e-838f-14d0ac36ec0a", //DEFAULT_CREATE_HOLDINGS_MAPPING_PROFILE_ID
-    "6a0ec1de-68eb-4833-bdbf-0741db25c314", //DEFAULT_CREATE_AUTHORITIES_MAPPING_PROFILE_ID
-    "6a0ec1de-68eb-4833-bdbf-0741db85c314", //DEFAULT_CREATE_AUTHORITY_MAPPING_PROFILE_ID
-    "39b265e1-c963-4e5f-859d-6e8c327a265c", //DEFAULT_QM_MARC_BIB_UPDATE_MAPPING_PROFILE_ID
-    "b8a9ca7d-4a33-44d3-86e1-f7c6cb7b265f", //DEFAULT_QM_HOLDINGS_UPDATE_MAPPING_PROFILE_ID
-    "041f8ff9-9d17-4436-b305-1033e0879501" //DEFAULT_QM_AUTHORITY_UPDATE_MAPPING_PROFILE_ID
-  };
-  private static final String[] ACTION_PROFILES = {
-    "d0ebba8a-2f0f-11eb-adc1-0242ac120002", //OCLC_CREATE_INSTANCE_ACTION_PROFILE_ID
-    "cddff0e1-233c-47ba-8be5-553c632709d9", //OCLC_UPDATE_INSTANCE_ACTION_PROFILE_ID
-    "6aa8e98b-0d9f-41dd-b26f-15658d07eb52", //OCLC_UPDATE_MARC_BIB_ACTION_PROFILE_ID
-    "f8e58651-f651-485d-aead-d2fa8700e2d1", //DEFAULT_CREATE_DERIVE_INSTANCE_ACTION_PROFILE_ID
-    "f5feddba-f892-4fad-b702-e4e77f04f9a3", //DEFAULT_CREATE_DERIVE_HOLDINGS_ACTION_PROFILE_ID
-    "8aa0b850-9182-4005-8435-340b704b2a19", //DEFAULT_CREATE_HOLDINGS_ACTION_PROFILE_ID
-    "7915c72e-c6af-4962-969d-403c7238b051", //DEFAULT_CREATE_AUTHORITIES_ACTION_PROFILE_ID
-    "7915c72e-c7af-4962-969d-403c7238b051", //DEFAULT_CREATE_AUTHORITIES_ACTION_PROFILE_ID
-    "fabd9a3e-33c3-49b7-864d-c5af830d9990", //DEFAULT_DELETE_MARC_AUTHORITY_ACTION_PROFILE_ID
-    "c2e2d482-9486-476e-a28c-8f1e303cbe1a", //DEFAULT_QM_MARC_BIB_UPDATE_ACTION_PROFILE_ID
-    "7e24a466-349b-451d-a18e-38fb21d71b38", //DEFAULT_QM_HOLDINGS_UPDATE_ACTION_PROFILE_ID
-    "f0f788c8-2e65-4e3a-9247-e9444eeb7d70" //DEFAULT_QM_AUTHORITY_UPDATE_ACTION_PROFILE_ID
-  };
 
   @Autowired
   private ProfileService<JobProfile, JobProfileCollection, JobProfileUpdateDto> jobProfileService;
@@ -444,23 +357,12 @@ public class DataImportProfilesImpl implements DataImportProfiles {
                                                    Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {
       try {
-        entity.getProfile().setMetadata(getMetadata(okapiHeaders));
-        composeFutureErrors(
-          validateActionProfile(OperationType.CREATE, entity.getProfile(), tenantId),
-          validateActionProfileAddedRelationsFolioRecord(entity, tenantId)).onComplete(errors -> {
-          if (errors.failed()) {
-            logger.warn(format(PROFILE_VALIDATE_ERROR_MESSAGE, entity.getClass().getSimpleName()), errors.cause());
-            asyncResultHandler.handle(Future.succeededFuture(ExceptionHelper.mapExceptionToResponse(errors.cause())));
-          } else if (errors.result().getTotalRecords() > 0) {
-            asyncResultHandler.handle(Future.succeededFuture(PostDataImportProfilesActionProfilesResponse.respond422WithApplicationJson(errors.result())));
-          } else {
-            actionProfileService.saveProfile(entity, new OkapiConnectionParams(okapiHeaders))
-              .map(profile -> (Response) PostDataImportProfilesActionProfilesResponse
-                .respond201WithApplicationJson(entity.withProfile(profile).withId(profile.getId()), PostDataImportProfilesActionProfilesResponse.headersFor201()))
-              .otherwise(ExceptionHelper::mapExceptionToResponse)
-              .onComplete(asyncResultHandler);
-          }
-        });
+
+        actionProfileService.saveProfile(entity, new OkapiConnectionParams(okapiHeaders))
+          .map(profile -> (Response) PostDataImportProfilesActionProfilesResponse
+            .respond201WithApplicationJson(entity.withProfile(profile).withId(profile.getId()), PostDataImportProfilesActionProfilesResponse.headersFor201()))
+          .otherwise(ExceptionHelper::mapExceptionToResponse)
+          .onComplete(asyncResultHandler);
       } catch (Exception e) {
         logger.warn("postDataImportProfilesActionProfiles:: Failed to create Action Profile", e);
         asyncResultHandler.handle(Future.succeededFuture(ExceptionHelper.mapExceptionToResponse(e)));
@@ -492,25 +394,12 @@ public class DataImportProfilesImpl implements DataImportProfiles {
                                                       Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {
       try {
-        actionProfileService.isProfileDtoValidForUpdate(id, entity, canDeleteOrUpdateProfile(id, ACTION_PROFILES), tenantId).compose(isDtoValidForUpdate -> {
-          if (isDtoValidForUpdate) {
-            entity.getProfile().setMetadata(getMetadata(okapiHeaders));
-            return composeFutureErrors(
-              validateActionProfile(OperationType.UPDATE, entity.getProfile(), tenantId),
-              validateActionProfileChildProfilesFolioRecord(entity, tenantId, id),
-              validateActionProfileAddedRelationsFolioRecord(entity, tenantId)
-            ).compose(errors -> {
-              entity.getProfile().setId(id);
-              return errors.getTotalRecords() > 0 ?
-                Future.succeededFuture(PutDataImportProfilesActionProfilesByIdResponse.respond422WithApplicationJson(errors)) :
-                actionProfileService.updateProfile(entity, new OkapiConnectionParams(okapiHeaders))
-                  .map(PutDataImportProfilesActionProfilesByIdResponse::respond200WithApplicationJson);
-            });
-          } else {
-            logger.warn("putDataImportProfilesActionProfilesById:: Can`t update default OCLC Action Profile with id {}", id);
-            return Future.succeededFuture(ExceptionHelper.mapExceptionToResponse(new BadRequestException(String.format("Can`t update default OCLC Action Profile with id %s", id))));
-          }
-        }).otherwise(ExceptionHelper::mapExceptionToResponse).onComplete(asyncResultHandler);
+        entity.getProfile().setMetadata(getMetadata(okapiHeaders));
+        entity.getProfile().setId(id);
+        actionProfileService.updateProfile(entity, new OkapiConnectionParams(okapiHeaders))
+          .map(PutDataImportProfilesActionProfilesByIdResponse::respond200WithApplicationJson)
+          .map(Response.class::cast)
+          .otherwise(ExceptionHelper::mapExceptionToResponse).onComplete(asyncResultHandler);
       } catch (Exception e) {
         logger.warn("putDataImportProfilesActionProfilesById:: Failed to update Action Profile with id {}", id, e);
         asyncResultHandler.handle(Future.succeededFuture(ExceptionHelper.mapExceptionToResponse(e)));
@@ -787,128 +676,6 @@ public class DataImportProfilesImpl implements DataImportProfiles {
     });
   }
 
-  private <T, S, D> Future<Errors> validateProfile(OperationType operationType, T profile, ProfileService<T, S, D> profileService, String tenantId) {
-    Promise<Errors> promise = Promise.promise();
-    String profileTypeName = StringUtils.uncapitalize(profile.getClass().getSimpleName());
-    Map<String, Future<Boolean>> validateConditions = getValidateConditions(operationType, profile, profileService, tenantId);
-    List<String> errorCodes = new ArrayList<>(validateConditions.keySet());
-    List<Future<Boolean>> futures = new ArrayList<>(validateConditions.values());
-    GenericCompositeFuture.all(futures).onComplete( ar -> {
-      if(ar.succeeded()) {
-        List<Error> errors = new ArrayList<>(errorCodes).stream()
-          .filter(errorCode -> ar.result().resultAt(errorCodes.indexOf(errorCode)))
-          .map(errorCode -> new Error().withMessage(format(errorCode,
-            ERROR_CODES_TYPES_RELATION.get(profileTypeName), profileService.getProfileName(profile))))
-          .collect(Collectors.toList());
-        promise.complete(new Errors().withErrors(errors).withTotalRecords(errors.size()));
-      } else {
-        promise.fail(ar.cause());
-      }
-    });
-    return promise.future();
-  }
-
-  private <T, S, D> Map<String, Future<Boolean>> getValidateConditions(OperationType operationType, T profile, ProfileService<T, S, D> profileService, String tenantId) {
-    Map<String, Future<Boolean>> validateConditions = new LinkedHashMap<>();
-    validateConditions.put(DUPLICATE_PROFILE_ERROR_CODE, profileService.isProfileExistByProfileName(profile, tenantId));
-    validateConditions.put(String.format(NOT_EMPTY_RELATED_PROFILE_ERROR_CODE, "%s", "child"), profileService.isProfileContainsChildProfiles(profile));
-    validateConditions.put(String.format(NOT_EMPTY_RELATED_PROFILE_ERROR_CODE, "%s", "parent"), profileService.isProfileContainsParentProfiles(profile));
-    if(operationType == OperationType.CREATE) {
-      validateConditions.put(DUPLICATE_PROFILE_ID_ERROR_CODE, profileService.isProfileExistByProfileId(profile, tenantId));
-    }
-    return validateConditions;
-  }
-
-  private Future<Errors> validateActionProfile(OperationType operationType, ActionProfile actionProfile, String tenantId) {
-    return validateProfile(operationType, actionProfile, actionProfileService, tenantId)
-      .map(errors -> {
-        if (ActionProfile.FolioRecord.MARC_BIBLIOGRAPHIC == actionProfile.getFolioRecord() && ActionProfile.Action.CREATE == actionProfile.getAction()) {
-          logger.warn("validateActionProfile:: {}", INVALID_ACTION_PROFILE_ACTION_TYPE);
-          errors.withTotalRecords(errors.getTotalRecords() + 1).getErrors().add(new Error().withMessage(INVALID_ACTION_PROFILE_ACTION_TYPE));
-        }
-        return errors;
-      });
-  }
-
-  private Future<Errors> validateActionProfileAddedRelationsFolioRecord(ActionProfileUpdateDto actionProfileUpdateDto, String tenantId) {
-    if (CollectionUtils.isEmpty(actionProfileUpdateDto.getAddedRelations())) {
-      return Future.succeededFuture(new Errors().withTotalRecords(0));
-    }
-
-    var errors = new LinkedList<Error>();
-    Promise<Errors> promise = Promise.promise();
-
-    var futures = actionProfileUpdateDto
-      .getAddedRelations()
-      .stream()
-      .filter(profileAssociation -> profileAssociation.getDetailProfileType() == ProfileType.MAPPING_PROFILE)
-      .map(profileAssociation -> mappingProfileService.getProfileById(profileAssociation.getDetailProfileId(), false, tenantId))
-      .map(futureMappingProfile -> futureMappingProfile.onSuccess(optionalMappingProfile ->
-        optionalMappingProfile.ifPresent(mappingProfile -> validateAssociations(actionProfileUpdateDto.getProfile(), mappingProfile, errors,
-          String.format(INVALID_RECORD_TYPE_LINKED_MAPPING_PROFILE_TO_ACTION_PROFILE, mappingProfile.getName())))
-      ))
-      .collect(Collectors.toList());
-    GenericCompositeFuture.all(futures)
-      .onSuccess(handler -> promise.complete(new Errors().withErrors(errors)))
-      .onFailure(promise::fail);
-
-    return promise.future();
-  }
-
-  private Future<Errors> validateActionProfileChildProfilesFolioRecord(ActionProfileUpdateDto actionProfileUpdateDto, String tenantId, String id) {
-    var errors = new LinkedList<Error>();
-    var deletedRelations = actionProfileUpdateDto.getDeletedRelations();
-    Promise<Errors> promise = Promise.promise();
-
-    actionProfileService.getProfileById(id, true, tenantId)
-      .onSuccess(optionalActionProfile ->
-        optionalActionProfile.ifPresentOrElse(actionProfile -> {
-            var existMappingProfiles = CollectionUtils.isEmpty(deletedRelations) ? actionProfile.getChildProfiles() :
-              actionProfile.getChildProfiles().stream()
-                .filter(profileSnapshotWrapper -> profileSnapshotWrapper.getContentType() == ProfileType.MAPPING_PROFILE)
-                .filter(profileSnapshotWrapper -> deletedRelations.stream()
-                  .noneMatch(rel -> Objects.equals(rel.getDetailProfileId(), profileSnapshotWrapper.getProfileId()))
-                ).toList();
-
-            existMappingProfiles.forEach(mappingWrapper -> {
-              var mappingProfile = DatabindCodec.mapper().convertValue(mappingWrapper.getContent(), MappingProfile.class);
-              validateAssociations(actionProfileUpdateDto.getProfile(), mappingProfile, errors, INVALID_ACTION_PROFILE_NEW_RECORD_TYPE_LINKED_TO_MAPPING_PROFILE);
-            });
-            promise.complete(new Errors().withErrors(errors));
-          }, () -> promise.fail(new NotFoundException(String.format("Action profile with id '%s' was not found", id)))
-        )
-      ).onFailure(promise::fail);
-
-    return promise.future();
-  }
-
-  private void validateAssociations(ActionProfile actionProfile, MappingProfile mappingProfile, List<Error> errors, String errMsg) {
-    var mappingRecordType = mappingProfile.getExistingRecordType().value();
-    var actionRecordType = actionProfile.getFolioRecord().value();
-    if (!actionRecordType.equals(mappingRecordType)) {
-      logger.info("validateAssociations:: Can not create or update profile. MappingProfile with ID:{} FolioRecord:{}, linked ActionProfile with ID:{} FolioRecord:{}",
-        mappingProfile.getId(), mappingRecordType, actionProfile.getId(), actionRecordType);
-      errors.add(new Error().withMessage(errMsg));
-      return;
-    }
-
-    Optional.ofNullable(mappingProfile.getMappingDetails())
-      .map(MappingDetail::getMarcMappingOption)
-      .filter(option -> !option.value().equals(actionProfile.getAction().value()))
-      .ifPresent(option -> {
-        logger.info("validateAssociations:: Can not create or update profile. ActionProfile Action:{}, linked MappingProfile Option:{}", actionProfile.getAction().value(), option);
-        errors.add(new Error().withMessage(INVALID_ACTION_TYPE_LINKED_ACTION_PROFILE_TO_MAPPING_PROFILE));
-      });
-  }
-
-  @SafeVarargs
-  private Future<Errors> composeFutureErrors(Future<Errors>... errorsFuture) {
-    return CompositeFutureImpl.all(errorsFuture).map(compositeFuture -> compositeFuture.list().stream()
-      .map(object -> (Errors) object)
-      .reduce(new Errors().withTotalRecords(0), (accumulator, errors) -> addAll(accumulator, errors.getErrors())
-      ));
-  }
-
   private ProfileType mapContentType(String contentType) {
     try {
       return ProfileType.fromValue(contentType);
@@ -947,15 +714,5 @@ public class DataImportProfilesImpl implements DataImportProfiles {
   private static String getJson(String strEncoded) {
     byte[] decodedBytes = Base64.getDecoder().decode(strEncoded);
     return new String(decodedBytes, StandardCharsets.UTF_8);
-  }
-
-  private boolean canDeleteOrUpdateProfile(String id, String... uids) {
-    return Arrays.asList(uids).contains(id);
-  }
-
-  private Errors addAll(Errors errors, List<Error> otherErrors) {
-    errors.withTotalRecords(errors.getTotalRecords() + otherErrors.size())
-      .getErrors().addAll(otherErrors);
-    return errors;
   }
 }

--- a/mod-di-converter-storage-server/src/main/java/org/folio/rest/impl/DataImportProfilesImpl.java
+++ b/mod-di-converter-storage-server/src/main/java/org/folio/rest/impl/DataImportProfilesImpl.java
@@ -240,18 +240,13 @@ public class DataImportProfilesImpl implements DataImportProfiles {
                                                       Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {
       try {
-        if ("6eefa4c6-bbf7-4845-ad82-de7fc5abd0e3".equals(id) || Arrays.asList(JOB_PROFILES).contains(id)) {
-          logger.warn("deleteDataImportProfilesJobProfilesById:: Can`t delete default OCLC Job Profile with id {}", id);
-          asyncResultHandler.handle(Future.succeededFuture(ExceptionHelper.mapExceptionToResponse(new BadRequestException("Can`t delete default OCLC Job Profile with"))));
-        } else {
-          OkapiConnectionParams params = new OkapiConnectionParams(okapiHeaders);
-          jobProfileService.hardDeleteProfile(id, params.getTenantId())
-            .map(DeleteDataImportProfilesJobProfilesByIdResponse.respond204WithTextPlain(
-              format("Job Profile with id '%s' was successfully deleted", id)))
-            .map(Response.class::cast)
-            .otherwise(ExceptionHelper::mapExceptionToResponse)
-            .onComplete(asyncResultHandler);
-        }
+        OkapiConnectionParams params = new OkapiConnectionParams(okapiHeaders);
+        jobProfileService.hardDeleteProfile(id, params.getTenantId())
+          .map(DeleteDataImportProfilesJobProfilesByIdResponse.respond204WithTextPlain(
+            format("Job Profile with id '%s' was successfully deleted", id)))
+          .map(Response.class::cast)
+          .otherwise(ExceptionHelper::mapExceptionToResponse)
+          .onComplete(asyncResultHandler);
       } catch (Exception e) {
         logger.warn("deleteDataImportProfilesJobProfilesById:: Failed to delete Job Profile with id {}", id, e);
         asyncResultHandler.handle(Future.succeededFuture(ExceptionHelper.mapExceptionToResponse(e)));
@@ -432,18 +427,13 @@ public class DataImportProfilesImpl implements DataImportProfiles {
   public void deleteDataImportProfilesMappingProfilesById(String id, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {
       try {
-        if (canDeleteOrUpdateProfile(id, MAPPING_PROFILES)) {
-          logger.warn("deleteDataImportProfilesMappingProfilesById:: Can`t delete default OCLC Mapping Profile with id {}", id);
-          asyncResultHandler.handle(Future.succeededFuture(ExceptionHelper.mapExceptionToResponse(new BadRequestException("Can`t delete default OCLC Mapping Profile"))));
-        } else {
-          OkapiConnectionParams params = new OkapiConnectionParams(okapiHeaders);
-          mappingProfileService.hardDeleteProfile(id, params.getTenantId())
-            .map(DeleteDataImportProfilesMappingProfilesByIdResponse.respond204WithTextPlain(
-              format("Mapping Profile with id '%s' was successfully deleted", id)))
-            .map(Response.class::cast)
-            .otherwise(ExceptionHelper::mapExceptionToResponse)
-            .onComplete(asyncResultHandler);
-        }
+        OkapiConnectionParams params = new OkapiConnectionParams(okapiHeaders);
+        mappingProfileService.hardDeleteProfile(id, params.getTenantId())
+          .map(DeleteDataImportProfilesMappingProfilesByIdResponse.respond204WithTextPlain(
+            format("Mapping Profile with id '%s' was successfully deleted", id)))
+          .map(Response.class::cast)
+          .otherwise(ExceptionHelper::mapExceptionToResponse)
+          .onComplete(asyncResultHandler);
       } catch (Exception e) {
         logger.warn("deleteDataImportProfilesMappingProfilesById:: Failed to delete Mapping Profile with id {}", id, e);
         asyncResultHandler.handle(Future.succeededFuture(ExceptionHelper.mapExceptionToResponse(e)));
@@ -474,18 +464,14 @@ public class DataImportProfilesImpl implements DataImportProfiles {
                                                         Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {
       try {
-        if (canDeleteOrUpdateProfile(id, MATCH_PROFILES)) {
-          logger.warn("deleteDataImportProfilesMatchProfilesById:: Can`t delete default OCLC Match Profile with id {}", id);
-          asyncResultHandler.handle(Future.succeededFuture(ExceptionHelper.mapExceptionToResponse(new BadRequestException("Can`t delete default OCLC Match Profile"))));
-        } else {
-          OkapiConnectionParams params = new OkapiConnectionParams(okapiHeaders);
-          matchProfileService.hardDeleteProfile(id, params.getTenantId())
-            .map(DeleteDataImportProfilesMatchProfilesByIdResponse.respond204WithTextPlain(
-              format("Match Profile with id '%s' was successfully deleted", id)))
-            .map(Response.class::cast)
-            .otherwise(ExceptionHelper::mapExceptionToResponse)
-            .onComplete(asyncResultHandler);
-        }
+        OkapiConnectionParams params = new OkapiConnectionParams(okapiHeaders);
+        matchProfileService.hardDeleteProfile(id, params.getTenantId())
+          .map(DeleteDataImportProfilesMatchProfilesByIdResponse.respond204WithTextPlain(
+            format("Match Profile with id '%s' was successfully deleted", id)))
+          .map(Response.class::cast)
+          .otherwise(ExceptionHelper::mapExceptionToResponse)
+          .onComplete(asyncResultHandler);
+
       } catch (Exception e) {
         logger.warn("deleteDataImportProfilesMatchProfilesById:: Failed to delete Match Profile with id {}", id, e);
         asyncResultHandler.handle(Future.succeededFuture(ExceptionHelper.mapExceptionToResponse(e)));
@@ -795,17 +781,12 @@ public class DataImportProfilesImpl implements DataImportProfiles {
                                                          Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {
       try {
-        if (canDeleteOrUpdateProfile(id, ACTION_PROFILES)) {
-          logger.warn("deleteDataImportProfilesActionProfilesById:: Can`t delete default OCLC Action Profile with id {}", id);
-          asyncResultHandler.handle(Future.succeededFuture(ExceptionHelper.mapExceptionToResponse(new BadRequestException("Can`t delete default OCLC Action Profile"))));
-        } else {
-          actionProfileService.hardDeleteProfile(id, tenantId)
-            .map(DeleteDataImportProfilesActionProfilesByIdResponse.respond204WithTextPlain(
-              format("Action Profile with id '%s' was successfully deleted", id)))
-            .map(Response.class::cast)
-            .otherwise(ExceptionHelper::mapExceptionToResponse)
-            .onComplete(asyncResultHandler);
-        }
+        actionProfileService.hardDeleteProfile(id, tenantId)
+          .map(DeleteDataImportProfilesActionProfilesByIdResponse.respond204WithTextPlain(
+            format("Action Profile with id '%s' was successfully deleted", id)))
+          .map(Response.class::cast)
+          .otherwise(ExceptionHelper::mapExceptionToResponse)
+          .onComplete(asyncResultHandler);
       } catch (Exception e) {
         logger.warn("deleteDataImportProfilesActionProfilesById:: Failed to delete Action Profile with id {}", id, e);
         asyncResultHandler.handle(Future.succeededFuture(ExceptionHelper.mapExceptionToResponse(e)));

--- a/mod-di-converter-storage-server/src/main/java/org/folio/rest/impl/util/ExceptionHelper.java
+++ b/mod-di-converter-storage-server/src/main/java/org/folio/rest/impl/util/ExceptionHelper.java
@@ -3,8 +3,10 @@ package org.folio.rest.impl.util;
 import io.vertx.core.Promise;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.folio.HttpStatus;
 import org.folio.rest.tools.utils.ValidationHelper;
 import org.folio.services.exception.ConflictException;
+import org.folio.services.exception.UnprocessableEntityException;
 
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.NotFoundException;
@@ -24,6 +26,12 @@ public final class ExceptionHelper {
   }
 
   public static Response mapExceptionToResponse(Throwable throwable) {
+    if (throwable instanceof UnprocessableEntityException unprocessableEntity) {
+      return Response.status(HttpStatus.HTTP_UNPROCESSABLE_ENTITY.toInt())
+        .type(MediaType.APPLICATION_JSON_TYPE)
+        .entity(unprocessableEntity.getErrors())
+        .build();
+    }
     if (throwable instanceof BadRequestException) {
       return Response.status(BAD_REQUEST.getStatusCode())
         .type(MediaType.TEXT_PLAIN)

--- a/mod-di-converter-storage-server/src/main/java/org/folio/services/AbstractProfileService.java
+++ b/mod-di-converter-storage-server/src/main/java/org/folio/services/AbstractProfileService.java
@@ -53,7 +53,6 @@ import static org.folio.rest.jaxrs.model.ProfileType.MAPPING_PROFILE;
  * @param <S> type of the collection of T entities
  */
 public abstract class AbstractProfileService<T, S, D> implements ProfileService<T, S, D> {
-
   private static final Logger LOGGER = LogManager.getLogger();
   private static final String GET_USER_URL = "/users?query=id==";
   private static final String DELETE_PROFILE_ERROR_MESSAGE = "Can not delete profile by id '%s' cause profile associated with other profiles";

--- a/mod-di-converter-storage-server/src/main/java/org/folio/services/AbstractProfileService.java
+++ b/mod-di-converter-storage-server/src/main/java/org/folio/services/AbstractProfileService.java
@@ -560,7 +560,7 @@ public abstract class AbstractProfileService<T, S, D> implements ProfileService<
     var mappingRecordType = mappingProfile.getExistingRecordType().value();
     var actionRecordType = actionProfile.getFolioRecord().value();
     if (!actionRecordType.equals(mappingRecordType)) {
-      LOGGER.info("validateAssociations:: Can not create or update profile. MappingProfile with ID:{} FolioRecord:{}, linked ActionProfile with ID:{} FolioRecord:{}",
+      LOGGER.warn("validateAssociations:: Can not create or update profile. MappingProfile with ID:{} FolioRecord:{}, linked ActionProfile with ID:{} FolioRecord:{}",
         mappingProfile.getId(), mappingRecordType, actionProfile.getId(), actionRecordType);
       errors.add(new Error().withMessage(errMsg));
       return;
@@ -570,7 +570,7 @@ public abstract class AbstractProfileService<T, S, D> implements ProfileService<
       .map(MappingDetail::getMarcMappingOption)
       .filter(option -> !option.value().equals(actionProfile.getAction().value()))
       .ifPresent(option -> {
-        LOGGER.info("validateAssociations:: Can not create or update profile. ActionProfile Action:{}, linked MappingProfile Option:{}", actionProfile.getAction().value(), option);
+        LOGGER.warn("validateAssociations:: Can not create or update profile. ActionProfile Action:{}, linked MappingProfile Option:{}", actionProfile.getAction().value(), option);
         errors.add(new Error().withMessage(INVALID_ACTION_TYPE_LINKED_ACTION_PROFILE_TO_MAPPING_PROFILE));
       });
   }

--- a/mod-di-converter-storage-server/src/main/java/org/folio/services/AbstractProfileService.java
+++ b/mod-di-converter-storage-server/src/main/java/org/folio/services/AbstractProfileService.java
@@ -299,8 +299,7 @@ public abstract class AbstractProfileService<T, S, D> implements ProfileService<
    * @param tenantId         - Tenant id from request
    * @return - boolean value. True if in the profile DTO has been changed only Tags
    */
-  @Override
-  public Future<Boolean> isProfileDtoValidForUpdate(String id, D profile, boolean isDefaultProfile, String tenantId) {
+  private Future<Boolean> isProfileDtoValidForUpdate(String id, D profile, boolean isDefaultProfile, String tenantId) {
     return isDefaultProfile ? getProfileById(id, false, tenantId).map(profileOptional ->
       profileOptional.map(fetchedProfile -> Stream.of(getProfile(profile), fetchedProfile).map(JsonObject::mapFrom)
         .peek(jsonObject -> {

--- a/mod-di-converter-storage-server/src/main/java/org/folio/services/AbstractProfileService.java
+++ b/mod-di-converter-storage-server/src/main/java/org/folio/services/AbstractProfileService.java
@@ -3,6 +3,7 @@ package org.folio.services;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.http.HttpMethod;
+import io.vertx.core.impl.future.CompositeFutureImpl;
 import io.vertx.core.json.JsonObject;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -13,6 +14,9 @@ import org.folio.okapi.common.GenericCompositeFuture;
 import org.folio.rest.impl.util.OkapiConnectionParams;
 import org.folio.rest.impl.util.RestUtil;
 import org.folio.rest.jaxrs.model.EntityTypeCollection;
+import org.folio.rest.jaxrs.model.Error;
+import org.folio.rest.jaxrs.model.Errors;
+import org.folio.rest.jaxrs.model.OperationType;
 import org.folio.rest.jaxrs.model.ProfileAssociation;
 import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
 import org.folio.rest.jaxrs.model.ProfileType;
@@ -20,13 +24,17 @@ import org.folio.rest.jaxrs.model.UserInfo;
 import org.folio.services.association.CommonProfileAssociationService;
 import org.folio.services.association.ProfileAssociationService;
 import org.folio.services.exception.ConflictException;
+import org.folio.services.exception.UnprocessableEntityException;
 import org.folio.services.util.EntityTypes;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import javax.ws.rs.BadRequestException;
 import javax.ws.rs.NotFoundException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -46,6 +54,16 @@ public abstract class AbstractProfileService<T, S, D> implements ProfileService<
   private static final Logger LOGGER = LogManager.getLogger();
   private static final String GET_USER_URL = "/users?query=id==";
   private static final String DELETE_PROFILE_ERROR_MESSAGE = "Can not delete profile by id '%s' cause profile associated with other profiles";
+  private static final String DUPLICATE_PROFILE_ERROR_CODE = "%s '%s' already exists";
+  private static final String DUPLICATE_PROFILE_ID_ERROR_CODE = "%s with id '%s' already exists";
+  private static final String NOT_EMPTY_RELATED_PROFILE_ERROR_CODE = "%s read-only '%s' field should be empty";
+  private static final String PROFILE_VALIDATE_ERROR_MESSAGE = "Failed to validate %s";
+  private static final Map<String, String> ERROR_CODES_TYPES_RELATION = Map.of(
+    "mappingProfile", "The field mapping profile",
+    "jobProfile", "Job profile",
+    "matchProfile", "Match profile",
+    "actionProfile", "Action profile"
+  );
 
   @Autowired
   protected ProfileAssociationService profileAssociationService;
@@ -93,12 +111,13 @@ public abstract class AbstractProfileService<T, S, D> implements ProfileService<
   }
 
   @Override
-  public Future<T> saveProfile(D profile, OkapiConnectionParams params) {
-    return setUserInfoForProfile(profile, params)
+  public Future<T> saveProfile(D profileDto, OkapiConnectionParams params) {
+    return processValidation(OperationType.CREATE, profileDto, params.getTenantId())
+      .compose(profile -> setUserInfoForProfile(profile, params))
       .compose(profileWithInfo -> profileDao.saveProfile(setProfileId(profileWithInfo), params.getTenantId())
-        .map(prepareAssociations((profile)))
-        .compose(ar -> deleteRelatedAssociations(getProfileAssociationToDelete(profile), params.getTenantId()))
-        .compose(ar -> saveRelatedAssociations(getProfileAssociationToAdd(profile), params.getTenantId()))
+        .map(prepareAssociations((profileDto)))
+        .compose(ar -> deleteRelatedAssociations(getProfileAssociationToDelete(profileDto), params.getTenantId()))
+        .compose(ar -> saveRelatedAssociations(getProfileAssociationToAdd(profileDto), params.getTenantId()))
         .map(profileWithInfo));
   }
 
@@ -218,13 +237,23 @@ public abstract class AbstractProfileService<T, S, D> implements ProfileService<
   }
 
   @Override
-  public Future<T> updateProfile(D profile, OkapiConnectionParams params) {
-    return setUserInfoForProfile(profile, params)
+  public Future<T> updateProfile(D profileDto, OkapiConnectionParams params) {
+    String profileId = getProfileId(getProfile(profileDto));
+    return isProfileDtoValidForUpdate(profileId, profileDto, canDeleteOrUpdateProfile(profileId, getDefaultProfiles()), params.getTenantId())
+      .compose(isDtoValidForUpdate -> {
+        if (!isDtoValidForUpdate) {
+          String errorMessage = String.format("Can`t update default %s with id %s", getProfileContentType(), profileId);
+          LOGGER.warn("updateProfile:: {}", errorMessage);
+          return Future.failedFuture(new BadRequestException(errorMessage));
+        }
+        return processValidation(OperationType.UPDATE, profileDto, params.getTenantId());
+      })
+      .compose(profile -> setUserInfoForProfile(profile, params))
       .compose(profileWithInfo -> profileDao.updateProfile(profileWithInfo, params.getTenantId()))
-      .map(prepareAssociations((profile)))
-      .compose(ar -> deleteRelatedAssociations(getProfileAssociationToDelete(profile), params.getTenantId()))
-      .compose(ar -> saveRelatedAssociations(getProfileAssociationToAdd(profile), params.getTenantId()))
-      .map(getProfile(profile));
+      .map(prepareAssociations((profileDto)))
+      .compose(ar -> deleteRelatedAssociations(getProfileAssociationToDelete(profileDto), params.getTenantId()))
+      .compose(ar -> saveRelatedAssociations(getProfileAssociationToAdd(profileDto), params.getTenantId()))
+      .map(getProfile(profileDto));
   }
 
   @Override
@@ -250,6 +279,15 @@ public abstract class AbstractProfileService<T, S, D> implements ProfileService<
       Future.succeededFuture(false) : getProfileById(profileId, false, tenantId).map(Optional::isPresent);
   }
 
+  /**
+   * Check profile to access another fields except tags
+   *
+   * @param id               - Profile id
+   * @param profile          - D DTO
+   * @param isDefaultProfile - True if the profile lists as default
+   * @param tenantId         - Tenant id from request
+   * @return - boolean value. True if in the profile DTO has been changed only Tags
+   */
   @Override
   public Future<Boolean> isProfileDtoValidForUpdate(String id, D profile, boolean isDefaultProfile, String tenantId) {
     return isDefaultProfile ? getProfileById(id, false, tenantId).map(profileOptional ->
@@ -292,7 +330,7 @@ public abstract class AbstractProfileService<T, S, D> implements ProfileService<
    * @param params  {@link OkapiConnectionParams}
    * @return Profile with filled userInfo field
    */
-  abstract Future<T> setUserInfoForProfile(D profile, OkapiConnectionParams params);
+  abstract Future<T> setUserInfoForProfile(T profile, OkapiConnectionParams params);
 
   /**
    * Returns name of specified profile
@@ -334,6 +372,8 @@ public abstract class AbstractProfileService<T, S, D> implements ProfileService<
   protected abstract List<ProfileAssociation> getProfileAssociationToDelete(D dto);
 
   protected abstract T getProfile(D dto);
+
+  protected abstract String[]  getDefaultProfiles();
 
   /**
    * Load all related child profiles for existing profile
@@ -460,5 +500,67 @@ public abstract class AbstractProfileService<T, S, D> implements ProfileService<
         }
       });
     return promise.future();
+  }
+
+  private Future<T> processValidation(OperationType operationType, D profileDto, String tenantId) {
+    return validateProfile(operationType, profileDto, tenantId)
+      .onFailure(th -> LOGGER.warn(PROFILE_VALIDATE_ERROR_MESSAGE, th.getCause()))
+      .compose(errors -> {
+        if (errors.getTotalRecords() > 0) {
+          return Future.failedFuture(new UnprocessableEntityException(errors));
+        }
+        return Future.succeededFuture(getProfile(profileDto));
+      });
+  }
+
+  protected Future<Errors> validateProfile(OperationType operationType, D profileDto, String tenantId) {
+    T profile = getProfile(profileDto);
+    Promise<Errors> promise = Promise.promise();
+    String profileTypeName = StringUtils.uncapitalize(profile.getClass().getSimpleName());
+    Map<String, Future<Boolean>> validateConditions = getValidateConditions(operationType, profile, tenantId);
+    List<String> errorCodes = new ArrayList<>(validateConditions.keySet());
+    List<Future<Boolean>> futures = new ArrayList<>(validateConditions.values());
+    GenericCompositeFuture.all(futures).onComplete(ar -> {
+      if (ar.succeeded()) {
+        List<Error> errors = new ArrayList<>(errorCodes).stream()
+          .filter(errorCode -> ar.result().resultAt(errorCodes.indexOf(errorCode)))
+          .map(errorCode -> new Error().withMessage(format(errorCode,
+            ERROR_CODES_TYPES_RELATION.get(profileTypeName), getProfileName(profile))))
+          .collect(Collectors.toList());
+        promise.complete(new Errors().withErrors(errors).withTotalRecords(errors.size()));
+      } else {
+        promise.fail(ar.cause());
+      }
+    });
+    return promise.future();
+  }
+
+  private Map<String, Future<Boolean>> getValidateConditions(OperationType operationType, T profile, String tenantId) {
+    Map<String, Future<Boolean>> validateConditions = new LinkedHashMap<>();
+    validateConditions.put(DUPLICATE_PROFILE_ERROR_CODE, isProfileExistByProfileName(profile, tenantId));
+    validateConditions.put(String.format(NOT_EMPTY_RELATED_PROFILE_ERROR_CODE, "%s", "child"), isProfileContainsChildProfiles(profile));
+    validateConditions.put(String.format(NOT_EMPTY_RELATED_PROFILE_ERROR_CODE, "%s", "parent"), isProfileContainsParentProfiles(profile));
+    if (operationType == OperationType.CREATE) {
+      validateConditions.put(DUPLICATE_PROFILE_ID_ERROR_CODE, isProfileExistByProfileId(profile, tenantId));
+    }
+    return validateConditions;
+  }
+
+  @SafeVarargs
+  protected final Future<Errors> composeFutureErrors(Future<Errors>... errorsFuture) {
+    return CompositeFutureImpl.all(errorsFuture).map(compositeFuture -> compositeFuture.list().stream()
+      .map(object -> (Errors) object)
+      .reduce(new Errors().withTotalRecords(0), (accumulator, errors) -> addAll(accumulator, errors.getErrors())
+      ));
+  }
+
+  private Errors addAll(Errors errors, List<Error> otherErrors) {
+    errors.withTotalRecords(errors.getTotalRecords() + otherErrors.size())
+      .getErrors().addAll(otherErrors);
+    return errors;
+  }
+
+  private boolean canDeleteOrUpdateProfile(String id, String... uids) {
+    return Arrays.asList(uids).contains(id);
   }
 }

--- a/mod-di-converter-storage-server/src/main/java/org/folio/services/ActionProfileServiceImpl.java
+++ b/mod-di-converter-storage-server/src/main/java/org/folio/services/ActionProfileServiceImpl.java
@@ -16,17 +16,31 @@ import java.util.UUID;
 
 @Component
 public class ActionProfileServiceImpl extends AbstractProfileService<ActionProfile, ActionProfileCollection, ActionProfileUpdateDto> {
+  private static final String[] DEFAULT_ACTION_PROFILES = {
+    "d0ebba8a-2f0f-11eb-adc1-0242ac120002", //OCLC_CREATE_INSTANCE_ACTION_PROFILE_ID
+    "cddff0e1-233c-47ba-8be5-553c632709d9", //OCLC_UPDATE_INSTANCE_ACTION_PROFILE_ID
+    "6aa8e98b-0d9f-41dd-b26f-15658d07eb52", //OCLC_UPDATE_MARC_BIB_ACTION_PROFILE_ID
+    "f8e58651-f651-485d-aead-d2fa8700e2d1", //DEFAULT_CREATE_DERIVE_INSTANCE_ACTION_PROFILE_ID
+    "f5feddba-f892-4fad-b702-e4e77f04f9a3", //DEFAULT_CREATE_DERIVE_HOLDINGS_ACTION_PROFILE_ID
+    "8aa0b850-9182-4005-8435-340b704b2a19", //DEFAULT_CREATE_HOLDINGS_ACTION_PROFILE_ID
+    "7915c72e-c6af-4962-969d-403c7238b051", //DEFAULT_CREATE_AUTHORITIES_ACTION_PROFILE_ID
+    "7915c72e-c7af-4962-969d-403c7238b051", //DEFAULT_CREATE_AUTHORITIES_ACTION_PROFILE_ID
+    "fabd9a3e-33c3-49b7-864d-c5af830d9990", //DEFAULT_DELETE_MARC_AUTHORITY_ACTION_PROFILE_ID
+    "c2e2d482-9486-476e-a28c-8f1e303cbe1a", //DEFAULT_QM_MARC_BIB_UPDATE_ACTION_PROFILE_ID
+    "7e24a466-349b-451d-a18e-38fb21d71b38", //DEFAULT_QM_HOLDINGS_UPDATE_ACTION_PROFILE_ID
+    "f0f788c8-2e65-4e3a-9247-e9444eeb7d70" //DEFAULT_QM_AUTHORITY_UPDATE_ACTION_PROFILE_ID
+  };
 
   @Override
-  public Future<ActionProfile> saveProfile(ActionProfileUpdateDto profile, OkapiConnectionParams params) {
-    setDefaults(profile.getProfile());
-    return super.saveProfile(profile, params);
+  public Future<ActionProfile> saveProfile(ActionProfileUpdateDto profileDto, OkapiConnectionParams params) {
+    setDefaults(profileDto.getProfile());
+    return super.saveProfile(profileDto, params);
   }
 
   @Override
-  public Future<ActionProfile> updateProfile(ActionProfileUpdateDto profile, OkapiConnectionParams params) {
-    setDefaults(profile.getProfile());
-    return super.updateProfile(profile, params);
+  public Future<ActionProfile> updateProfile(ActionProfileUpdateDto profileDto, OkapiConnectionParams params) {
+    setDefaults(profileDto.getProfile());
+    return super.updateProfile(profileDto, params);
   }
   @Override
   ActionProfile setProfileId(ActionProfile profile) {
@@ -36,9 +50,9 @@ public class ActionProfileServiceImpl extends AbstractProfileService<ActionProfi
   }
 
   @Override
-  Future<ActionProfile> setUserInfoForProfile(ActionProfileUpdateDto profile, OkapiConnectionParams params) {
-    return lookupUser(profile.getProfile().getMetadata().getUpdatedByUserId(), params)
-      .compose(userInfo -> Future.succeededFuture(profile.getProfile().withUserInfo(userInfo)));
+  Future<ActionProfile> setUserInfoForProfile(ActionProfile profile, OkapiConnectionParams params) {
+    return lookupUser(profile.getMetadata().getUpdatedByUserId(), params)
+      .compose(userInfo -> Future.succeededFuture(profile.withUserInfo(userInfo)));
   }
 
   @Override
@@ -107,6 +121,11 @@ public class ActionProfileServiceImpl extends AbstractProfileService<ActionProfi
   @Override
   protected ActionProfile getProfile(ActionProfileUpdateDto dto) {
     return dto.getProfile();
+  }
+
+  @Override
+  protected String[] getDefaultProfiles() {
+    return DEFAULT_ACTION_PROFILES;
   }
 
   private void setDefaults(ActionProfile profile) {

--- a/mod-di-converter-storage-server/src/main/java/org/folio/services/ActionProfileServiceImpl.java
+++ b/mod-di-converter-storage-server/src/main/java/org/folio/services/ActionProfileServiceImpl.java
@@ -30,7 +30,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 @Component
 public class ActionProfileServiceImpl extends AbstractProfileService<ActionProfile, ActionProfileCollection, ActionProfileUpdateDto> {
@@ -38,9 +37,6 @@ public class ActionProfileServiceImpl extends AbstractProfileService<ActionProfi
   private static final String INVALID_ACTION_PROFILE_ACTION_TYPE = "Can't create ActionProfile for MARC Bib record type with Create action";
   private static final String INVALID_RECORD_TYPE_LINKED_MAPPING_PROFILE_TO_ACTION_PROFILE = "Mapping profile '%s' can not be linked to this Action profile. ExistingRecordType and FolioRecord types are different";
   private static final String INVALID_ACTION_PROFILE_NEW_RECORD_TYPE_LINKED_TO_MAPPING_PROFILE = "Can not update ActionProfile recordType and linked MappingProfile recordType are different";
-
-  @Autowired
-  private ProfileService<MappingProfile, MappingProfileCollection, MappingProfileUpdateDto> mappingProfileService;
   private static final List<String> DEFAULT_ACTION_PROFILES = Arrays.asList(
     "d0ebba8a-2f0f-11eb-adc1-0242ac120002", //OCLC_CREATE_INSTANCE_ACTION_PROFILE_ID
     "cddff0e1-233c-47ba-8be5-553c632709d9", //OCLC_UPDATE_INSTANCE_ACTION_PROFILE_ID
@@ -55,6 +51,9 @@ public class ActionProfileServiceImpl extends AbstractProfileService<ActionProfi
     "7e24a466-349b-451d-a18e-38fb21d71b38", //DEFAULT_QM_HOLDINGS_UPDATE_ACTION_PROFILE_ID
     "f0f788c8-2e65-4e3a-9247-e9444eeb7d70" //DEFAULT_QM_AUTHORITY_UPDATE_ACTION_PROFILE_ID
   );
+
+  @Autowired
+  private ProfileService<MappingProfile, MappingProfileCollection, MappingProfileUpdateDto> mappingProfileService;
 
   @Override
   public Future<ActionProfile> saveProfile(ActionProfileUpdateDto profileDto, OkapiConnectionParams params) {
@@ -197,7 +196,7 @@ public class ActionProfileServiceImpl extends AbstractProfileService<ActionProfi
         optionalMappingProfile.ifPresent(mappingProfile -> validateAssociations(actionProfileUpdateDto.getProfile(), mappingProfile, errors,
           String.format(INVALID_RECORD_TYPE_LINKED_MAPPING_PROFILE_TO_ACTION_PROFILE, mappingProfile.getName())))
       ))
-      .collect(Collectors.toList());
+      .toList();
     GenericCompositeFuture.all(futures)
       .onSuccess(handler -> promise.complete(new Errors().withErrors(errors)))
       .onFailure(promise::fail);

--- a/mod-di-converter-storage-server/src/main/java/org/folio/services/ActionProfileServiceImpl.java
+++ b/mod-di-converter-storage-server/src/main/java/org/folio/services/ActionProfileServiceImpl.java
@@ -11,12 +11,13 @@ import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
 import org.folio.rest.jaxrs.model.ProfileType;
 import org.springframework.stereotype.Component;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 
 @Component
 public class ActionProfileServiceImpl extends AbstractProfileService<ActionProfile, ActionProfileCollection, ActionProfileUpdateDto> {
-  private static final String[] DEFAULT_ACTION_PROFILES = {
+  private static final List<String> DEFAULT_ACTION_PROFILES = Arrays.asList(
     "d0ebba8a-2f0f-11eb-adc1-0242ac120002", //OCLC_CREATE_INSTANCE_ACTION_PROFILE_ID
     "cddff0e1-233c-47ba-8be5-553c632709d9", //OCLC_UPDATE_INSTANCE_ACTION_PROFILE_ID
     "6aa8e98b-0d9f-41dd-b26f-15658d07eb52", //OCLC_UPDATE_MARC_BIB_ACTION_PROFILE_ID
@@ -29,7 +30,7 @@ public class ActionProfileServiceImpl extends AbstractProfileService<ActionProfi
     "c2e2d482-9486-476e-a28c-8f1e303cbe1a", //DEFAULT_QM_MARC_BIB_UPDATE_ACTION_PROFILE_ID
     "7e24a466-349b-451d-a18e-38fb21d71b38", //DEFAULT_QM_HOLDINGS_UPDATE_ACTION_PROFILE_ID
     "f0f788c8-2e65-4e3a-9247-e9444eeb7d70" //DEFAULT_QM_AUTHORITY_UPDATE_ACTION_PROFILE_ID
-  };
+  );
 
   @Override
   public Future<ActionProfile> saveProfile(ActionProfileUpdateDto profileDto, OkapiConnectionParams params) {
@@ -124,7 +125,7 @@ public class ActionProfileServiceImpl extends AbstractProfileService<ActionProfi
   }
 
   @Override
-  protected String[] getDefaultProfiles() {
+  protected List<String> getDefaultProfiles() {
     return DEFAULT_ACTION_PROFILES;
   }
 

--- a/mod-di-converter-storage-server/src/main/java/org/folio/services/JobProfileServiceImpl.java
+++ b/mod-di-converter-storage-server/src/main/java/org/folio/services/JobProfileServiceImpl.java
@@ -227,7 +227,7 @@ public class JobProfileServiceImpl extends AbstractProfileService<JobProfile, Jo
     return profileAssociations.stream()
       .filter(profileAssociation -> profileAssociation.getDetailProfileType() != ProfileType.MAPPING_PROFILE &&
         profileAssociation.getDetailProfileType() != ProfileType.JOB_PROFILE)
-      .toList();
+      .collect(Collectors.toList());
   }
 
   private List<ProfileAssociation> removeDeletedProfileAssociations(List<ProfileAssociation> profileAssociations,

--- a/mod-di-converter-storage-server/src/main/java/org/folio/services/JobProfileServiceImpl.java
+++ b/mod-di-converter-storage-server/src/main/java/org/folio/services/JobProfileServiceImpl.java
@@ -49,7 +49,7 @@ public class JobProfileServiceImpl extends AbstractProfileService<JobProfile, Jo
   private static final String MODIFY_ACTION_CANNOT_BE_USED_AS_A_STANDALONE_ACTION = "Modify action cannot be used as a standalone action";
   private static final String MODIFY_ACTION_CANNOT_BE_USED_RIGHT_AFTER_THE_MATCH = "Modify action cannot be used right after a Match";
   private static final String LINKED_MATCH_PROFILES_WERE_NOT_FOUND = "Linked MatchProfiles with ids %s were not found";
-  private static final String DEFAULT_CREATE_SRS_MARC_AUTHORITY_JOB_PROFILE_ID = "6eefa4c6-bbf7-4845-ad82-de7fc5abd0e3";
+  private static final String DEFAULT_CREATE_SRS_MARC_AUTHORITY_JOB_PROFILE_ID = "6eefa4c6-bbf7-4845-ad82-de7fc5abd0e3"; //NOSONAR
   private static final List<String> DEFAULT_JOB_PROFILES = Arrays.asList(
     "d0ebb7b0-2f0f-11eb-adc1-0242ac120002", //OCLC_CREATE_INSTANCE_JOB_PROFILE_ID,
     "91f9b8d6-d80e-4727-9783-73fb53e3c786", //OCLC_UPDATE_INSTANCE_JOB_PROFILE_ID,

--- a/mod-di-converter-storage-server/src/main/java/org/folio/services/JobProfileServiceImpl.java
+++ b/mod-di-converter-storage-server/src/main/java/org/folio/services/JobProfileServiceImpl.java
@@ -28,6 +28,7 @@ import org.springframework.stereotype.Component;
 
 import javax.ws.rs.NotFoundException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.LinkedList;
@@ -48,7 +49,8 @@ public class JobProfileServiceImpl extends AbstractProfileService<JobProfile, Jo
   private static final String MODIFY_ACTION_CANNOT_BE_USED_AS_A_STANDALONE_ACTION = "Modify action cannot be used as a standalone action";
   private static final String MODIFY_ACTION_CANNOT_BE_USED_RIGHT_AFTER_THE_MATCH = "Modify action cannot be used right after a Match";
   private static final String LINKED_MATCH_PROFILES_WERE_NOT_FOUND = "Linked MatchProfiles with ids %s were not found";
-  private static final String[] DEFAULT_JOB_PROFILES = {
+  private static final String DEFAULT_CREATE_SRS_MARC_AUTHORITY_JOB_PROFILE_ID = "6eefa4c6-bbf7-4845-ad82-de7fc5abd0e3";
+  private static final List<String> DEFAULT_JOB_PROFILES = Arrays.asList(
     "d0ebb7b0-2f0f-11eb-adc1-0242ac120002", //OCLC_CREATE_INSTANCE_JOB_PROFILE_ID,
     "91f9b8d6-d80e-4727-9783-73fb53e3c786", //OCLC_UPDATE_INSTANCE_JOB_PROFILE_ID,
     "fa0262c7-5816-48d0-b9b3-7b7a862a5bc7", //DEFAULT_CREATE_DERIVE_HOLDINGS_JOB_PROFILE_ID
@@ -59,7 +61,7 @@ public class JobProfileServiceImpl extends AbstractProfileService<JobProfile, Jo
     "6cb347c6-c0b0-4363-89fc-32cedede87ba", //DEFAULT_QM_HOLDINGS_UPDATE_JOB_PROFILE_ID
     "c7fcbc40-c4c0-411d-b569-1fc6bc142a92",
     "6eefa4c6-bbf7-4845-ad82-de7fc4abd0e3"//DEFAULT_QM_AUTHORITY_CREATE_JOB_PROFILE_ID
-  };
+  );
   @Autowired
   private ProfileService<ActionProfile, ActionProfileCollection, ActionProfileUpdateDto> actionProfileService;
   @Autowired
@@ -157,7 +159,7 @@ public class JobProfileServiceImpl extends AbstractProfileService<JobProfile, Jo
   }
 
   @Override
-  protected String[] getDefaultProfiles() {
+  protected List<String> getDefaultProfiles() {
     return DEFAULT_JOB_PROFILES;
   }
 
@@ -169,6 +171,11 @@ public class JobProfileServiceImpl extends AbstractProfileService<JobProfile, Jo
       validateJobProfileLinkedActionProfiles(profileDto, tenantId),
       validateJobProfileLinkedMatchProfile(profileDto, tenantId)
     );
+  }
+
+  @Override
+  protected boolean canDeleteProfile(String profileId) {
+    return !DEFAULT_CREATE_SRS_MARC_AUTHORITY_JOB_PROFILE_ID.equals(profileId) && super.canDeleteProfile(profileId);
   }
 
   private Future<Errors> validateJobProfileAssociations(JobProfileUpdateDto entity, String tenantId) {
@@ -220,7 +227,7 @@ public class JobProfileServiceImpl extends AbstractProfileService<JobProfile, Jo
     return profileAssociations.stream()
       .filter(profileAssociation -> profileAssociation.getDetailProfileType() != ProfileType.MAPPING_PROFILE &&
         profileAssociation.getDetailProfileType() != ProfileType.JOB_PROFILE)
-      .collect(Collectors.toList());
+      .toList();
   }
 
   private List<ProfileAssociation> removeDeletedProfileAssociations(List<ProfileAssociation> profileAssociations,
@@ -255,7 +262,7 @@ public class JobProfileServiceImpl extends AbstractProfileService<JobProfile, Jo
     var actionProfileIds = actionProfileAssociations.stream().map(ProfileAssociation::getDetailProfileId).toList();
     var getProfileFutures = actionProfileIds.stream()
       .map(id -> actionProfileService.getProfileById(id, false, tenantId))
-      .collect(Collectors.toList());
+      .toList();
 
     return GenericCompositeFuture.all(getProfileFutures)
       .compose(actionProfiles -> {
@@ -347,7 +354,7 @@ public class JobProfileServiceImpl extends AbstractProfileService<JobProfile, Jo
 
     var futures = matchProfileIds.stream()
       .map(id -> matchProfileService.getProfileById(id, false, tenantId))
-      .collect(Collectors.toList());
+      .toList();
 
     return GenericCompositeFuture.all(futures)
       .compose(matchProfiles -> {

--- a/mod-di-converter-storage-server/src/main/java/org/folio/services/JobProfileServiceImpl.java
+++ b/mod-di-converter-storage-server/src/main/java/org/folio/services/JobProfileServiceImpl.java
@@ -62,6 +62,7 @@ public class JobProfileServiceImpl extends AbstractProfileService<JobProfile, Jo
     "c7fcbc40-c4c0-411d-b569-1fc6bc142a92",
     "6eefa4c6-bbf7-4845-ad82-de7fc4abd0e3"//DEFAULT_QM_AUTHORITY_CREATE_JOB_PROFILE_ID
   );
+
   @Autowired
   private ProfileService<ActionProfile, ActionProfileCollection, ActionProfileUpdateDto> actionProfileService;
   @Autowired

--- a/mod-di-converter-storage-server/src/main/java/org/folio/services/JobProfileServiceImpl.java
+++ b/mod-di-converter-storage-server/src/main/java/org/folio/services/JobProfileServiceImpl.java
@@ -1,23 +1,71 @@
 package org.folio.services;
 
 import io.vertx.core.Future;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.folio.okapi.common.GenericCompositeFuture;
 import org.folio.rest.impl.util.OkapiConnectionParams;
+import org.folio.rest.jaxrs.model.ActionProfile;
+import org.folio.rest.jaxrs.model.ActionProfileCollection;
+import org.folio.rest.jaxrs.model.ActionProfileUpdateDto;
+import org.folio.rest.jaxrs.model.Error;
+import org.folio.rest.jaxrs.model.Errors;
 import org.folio.rest.jaxrs.model.JobProfile;
 import org.folio.rest.jaxrs.model.JobProfileCollection;
 import org.folio.rest.jaxrs.model.JobProfileUpdateDto;
+import org.folio.rest.jaxrs.model.MatchProfile;
+import org.folio.rest.jaxrs.model.MatchProfileCollection;
+import org.folio.rest.jaxrs.model.MatchProfileUpdateDto;
+import org.folio.rest.jaxrs.model.OperationType;
 import org.folio.rest.jaxrs.model.ProfileAssociation;
 import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
 import org.folio.rest.jaxrs.model.ProfileType;
+import org.folio.services.snapshot.ProfileSnapshotService;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import javax.ws.rs.NotFoundException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
+import static org.folio.rest.jaxrs.model.ProfileType.ACTION_PROFILE;
 import static org.folio.rest.jaxrs.model.ProfileType.MATCH_PROFILE;
 
 @Component
 public class JobProfileServiceImpl extends AbstractProfileService<JobProfile, JobProfileCollection, JobProfileUpdateDto> {
+  private static final Logger LOGGER = LogManager.getLogger();
+  private static final String LINKED_ACTION_PROFILES_WERE_NOT_FOUND = "Linked ActionProfiles with ids %s were not found";
+  private static final String INVALID_ACTION_PROFILE_LINKED_TO_JOB_PROFILE = "ActionProfile with id '%s' and action UPDATE requires linked MatchProfile";
+  private static final String MODIFY_ACTION_CANNOT_BE_USED_AS_A_STANDALONE_ACTION = "Modify action cannot be used as a standalone action";
+  private static final String MODIFY_ACTION_CANNOT_BE_USED_RIGHT_AFTER_THE_MATCH = "Modify action cannot be used right after a Match";
+  private static final String LINKED_MATCH_PROFILES_WERE_NOT_FOUND = "Linked MatchProfiles with ids %s were not found";
+  private static final String[] DEFAULT_JOB_PROFILES = {
+    "d0ebb7b0-2f0f-11eb-adc1-0242ac120002", //OCLC_CREATE_INSTANCE_JOB_PROFILE_ID,
+    "91f9b8d6-d80e-4727-9783-73fb53e3c786", //OCLC_UPDATE_INSTANCE_JOB_PROFILE_ID,
+    "fa0262c7-5816-48d0-b9b3-7b7a862a5bc7", //DEFAULT_CREATE_DERIVE_HOLDINGS_JOB_PROFILE_ID
+    "6409dcff-71fa-433a-bc6a-e70ad38a9604", //DEFAULT_CREATE_DERIVE_INSTANCE_JOB_PROFILE_ID
+    "80898dee-449f-44dd-9c8e-37d5eb469b1d", //DEFAULT_CREATE_HOLDINGS_AND_SRS_MARC_HOLDINGS_JOB_PROFILE_ID
+    "1a338fcd-3efc-4a03-b007-394eeb0d5fb9", //DEFAULT_DELETE_MARC_AUTHORITY_JOB_PROFILE_ID
+    "cf6f2718-5aa5-482a-bba5-5bc9b75614da", //DEFAULT_QM_MARC_BIB_UPDATE_JOB_PROFILE_ID
+    "6cb347c6-c0b0-4363-89fc-32cedede87ba", //DEFAULT_QM_HOLDINGS_UPDATE_JOB_PROFILE_ID
+    "c7fcbc40-c4c0-411d-b569-1fc6bc142a92",
+    "6eefa4c6-bbf7-4845-ad82-de7fc4abd0e3"//DEFAULT_QM_AUTHORITY_CREATE_JOB_PROFILE_ID
+  };
+  @Autowired
+  private ProfileService<ActionProfile, ActionProfileCollection, ActionProfileUpdateDto> actionProfileService;
+  @Autowired
+  private ProfileService<MatchProfile, MatchProfileCollection, MatchProfileUpdateDto> matchProfileService;
+  @Autowired
+  private ProfileSnapshotService profileSnapshotService;
 
   @Override
   JobProfile setProfileId(JobProfile profile) {
@@ -27,9 +75,9 @@ public class JobProfileServiceImpl extends AbstractProfileService<JobProfile, Jo
   }
 
   @Override
-  Future<JobProfile> setUserInfoForProfile(JobProfileUpdateDto profile, OkapiConnectionParams params) {
-    return lookupUser(profile.getProfile().getMetadata().getUpdatedByUserId(), params)
-      .compose(userInfo -> Future.succeededFuture(profile.getProfile().withUserInfo(userInfo)));
+  Future<JobProfile> setUserInfoForProfile(JobProfile profile, OkapiConnectionParams params) {
+    return lookupUser(profile.getMetadata().getUpdatedByUserId(), params)
+      .compose(userInfo -> Future.succeededFuture(profile.withUserInfo(userInfo)));
   }
 
   @Override
@@ -108,4 +156,230 @@ public class JobProfileServiceImpl extends AbstractProfileService<JobProfile, Jo
     return dto.getProfile();
   }
 
+  @Override
+  protected String[] getDefaultProfiles() {
+    return DEFAULT_JOB_PROFILES;
+  }
+
+  @Override
+  protected Future<Errors> validateProfile(OperationType operationType, JobProfileUpdateDto profileDto, String tenantId) {
+    return composeFutureErrors(
+      validateJobProfileAssociations(profileDto, tenantId),
+      super.validateProfile(operationType, profileDto, tenantId),
+      validateJobProfileLinkedActionProfiles(profileDto, tenantId),
+      validateJobProfileLinkedMatchProfile(profileDto, tenantId)
+    );
+  }
+
+  private Future<Errors> validateJobProfileAssociations(JobProfileUpdateDto entity, String tenantId) {
+    String jobProfileId = entity.getProfile().getId();
+    Future<List<ProfileAssociation>> existingJobProfileAssociationsFuture = (jobProfileId != null) ?
+      profileSnapshotService.getSnapshotAssociations(jobProfileId, ProfileType.JOB_PROFILE, jobProfileId, tenantId):
+      Future.succeededFuture(new ArrayList<>());
+
+    List<Error> errors = new LinkedList<>();
+    return existingJobProfileAssociationsFuture
+      .map(this::filterProfileAssociations)
+      .map(profileAssociations -> removeDeletedProfileAssociations(profileAssociations, entity))
+      .compose(profileAssociations -> validateJobProfileAssociations(profileAssociations, errors));
+  }
+
+  private Future<Errors> validateJobProfileLinkedActionProfiles(JobProfileUpdateDto jobProfileUpdateDto, String tenantId) {
+    String jobProfileId = jobProfileUpdateDto.getProfile().getId();
+    LOGGER.debug("validateJobProfileLinkedActionProfiles:: Validating ActionProfiles added to JobProfile {}", jobProfileId);
+    List<Error> errors = new LinkedList<>();
+    Future<List<ProfileAssociation>> existingJobProfileAssociationsFuture;
+    if (jobProfileId != null) {
+      existingJobProfileAssociationsFuture = profileSnapshotService.getSnapshotAssociations(jobProfileId, ProfileType.JOB_PROFILE, jobProfileId, tenantId);
+    } else {
+      existingJobProfileAssociationsFuture = Future.succeededFuture(new ArrayList<>());
+    }
+
+    return existingJobProfileAssociationsFuture
+      .map(this::filterProfileAssociations)
+      .map(profileAssociations -> removeDeletedProfileAssociations(profileAssociations, jobProfileUpdateDto))
+      .compose(profileAssociations -> validateActionProfilesAssociations(profileAssociations, errors, tenantId));
+  }
+
+  private Future<Errors> validateJobProfileLinkedMatchProfile(JobProfileUpdateDto jobProfileUpdateDto, String tenantId) {
+    String jobProfileId = jobProfileUpdateDto.getProfile().getId();
+    LOGGER.debug("validateJobProfileLinkedMatchProfile:: Validating MatchProfiles added to JobProfile {}", jobProfileId);
+
+    List<Error> errors = new LinkedList<>();
+    Future<List<ProfileAssociation>> existingJobProfileAssociationsFuture = (jobProfileId != null) ?
+      profileSnapshotService.getSnapshotAssociations(jobProfileId, ProfileType.JOB_PROFILE, jobProfileId, tenantId):
+      Future.succeededFuture(new ArrayList<>());
+
+    return existingJobProfileAssociationsFuture
+      .map(this::filterProfileAssociations)
+      .map(profileAssociations -> removeDeletedProfileAssociations(profileAssociations, jobProfileUpdateDto))
+      .compose(profileAssociations -> validateJobProfileLinkedMatchProfile(profileAssociations, errors, tenantId));
+  }
+
+  private List<ProfileAssociation> filterProfileAssociations(List<ProfileAssociation> profileAssociations) {
+    return profileAssociations.stream()
+      .filter(profileAssociation -> profileAssociation.getDetailProfileType() != ProfileType.MAPPING_PROFILE &&
+        profileAssociation.getDetailProfileType() != ProfileType.JOB_PROFILE)
+      .collect(Collectors.toList());
+  }
+
+  private List<ProfileAssociation> removeDeletedProfileAssociations(List<ProfileAssociation> profileAssociations,
+                                                                    JobProfileUpdateDto jobProfileUpdateDto) {
+    if (!profileAssociations.isEmpty() && !jobProfileUpdateDto.getDeletedRelations().isEmpty()) {
+      profileAssociations.removeIf(profileAssociation ->
+        jobProfileUpdateDto.getDeletedRelations().stream().anyMatch(deleteAssociation -> {
+            if (profileAssociation.getId() != null && deleteAssociation.getId() != null) {
+              return Objects.equals(profileAssociation.getId(), deleteAssociation.getId());
+            }
+            return Objects.equals(profileAssociation.getMasterWrapperId(), deleteAssociation.getMasterWrapperId()) &&
+              Objects.equals(profileAssociation.getDetailWrapperId(), deleteAssociation.getDetailWrapperId());
+          }
+        )
+      );
+    }
+    profileAssociations.addAll(jobProfileUpdateDto.getAddedRelations());
+    return profileAssociations;
+  }
+
+  private Future<Errors> validateJobProfileAssociations(List<ProfileAssociation> profileAssociations, List<Error> errors) {
+    LOGGER.debug("validateJobProfileAssociations:: Validating JobProfile if it contains associations");
+    if (CollectionUtils.isEmpty(profileAssociations)) {
+      LOGGER.warn("validateJobProfileAssociations:: Job profile does not contain any associations");
+      errors.add(new Error().withMessage("Job profile does not contain any associations"));
+    }
+    return Future.succeededFuture(new Errors().withErrors(errors).withTotalRecords(errors.size()));
+  }
+
+  private Future<Errors> validateActionProfilesAssociations(List<ProfileAssociation> profileAssociations, List<Error> errors, String tenantId) {
+    var actionProfileAssociations = actionProfileAssociations(profileAssociations);
+    var actionProfileIds = actionProfileAssociations.stream().map(ProfileAssociation::getDetailProfileId).toList();
+    var getProfileFutures = actionProfileIds.stream()
+      .map(id -> actionProfileService.getProfileById(id, false, tenantId))
+      .collect(Collectors.toList());
+
+    return GenericCompositeFuture.all(getProfileFutures)
+      .compose(actionProfiles -> {
+        List<ActionProfile> existingActionProfiles = actionProfiles.result().<Optional<ActionProfile>>list().stream()
+          .filter(Optional::isPresent).map(Optional::get).toList();
+
+        var existingActionProfilesIds = existingActionProfiles.stream().map(ActionProfile::getId).toList();
+        var notFoundedIds = actionProfileIds.stream()
+          .filter(id -> !existingActionProfilesIds.contains(id))
+          .map(notFoundedId -> String.format("'%s'", notFoundedId)).toList();
+
+        if (!notFoundedIds.isEmpty()) {
+          var idStr = String.join(", ", notFoundedIds);
+          LOGGER.warn("validateActionProfilesAssociations:: Linked ActionProfiles with ids {} not founded", idStr);
+          return Future.failedFuture(new NotFoundException((String.format(LINKED_ACTION_PROFILES_WERE_NOT_FOUND, idStr))));
+        }
+        return Future.succeededFuture(existingActionProfiles);
+      })
+      .compose(actionProfiles -> {
+        actionProfileAssociations.forEach(association -> {
+          ActionProfile actionProfile = actionProfiles.stream()
+            .filter(profile -> profile.getId().equals(association.getDetailProfileId()))
+            .findAny().orElseThrow(() -> new NotFoundException(String.format(LINKED_ACTION_PROFILES_WERE_NOT_FOUND, association.getDetailProfileId())));
+
+          if (actionProfile.getAction() == ActionProfile.Action.UPDATE) {
+            validateAddedUpdateActionProfileAssociation(association, actionProfile, errors);
+          }
+          if (actionProfile.getAction() == ActionProfile.Action.MODIFY) {
+            validateAddedModifyActionProfileAssociation(profileAssociations, association, actionProfile, actionProfiles, errors);
+          }
+        });
+        return Future.succeededFuture(new Errors().withErrors(errors).withTotalRecords(errors.size()));
+      });
+  }
+
+  private List<ProfileAssociation> actionProfileAssociations(List<ProfileAssociation> profileAssociations) {
+    return profileAssociations.stream()
+      .filter(association -> association.getDetailProfileType() == ACTION_PROFILE).toList();
+  }
+
+  private static void validateAddedUpdateActionProfileAssociation(ProfileAssociation association, ActionProfile actionProfile, List<Error> errors) {
+    if (association.getMasterProfileType() != MATCH_PROFILE) {
+      LOGGER.warn("validateAddedUpdateActionProfileAssociation:: Missing linked MatchProfile for ActionProfile {} with action UPDATE", actionProfile.getId());
+      errors.add(new Error().withMessage(String.format(INVALID_ACTION_PROFILE_LINKED_TO_JOB_PROFILE, actionProfile.getId())));
+    }
+  }
+
+  private static void validateAddedModifyActionProfileAssociation(List<ProfileAssociation> profileAssociations, ProfileAssociation association, ActionProfile actionProfile,
+                                                                  List<ActionProfile> actionProfiles, List<Error> errors) {
+    List<ProfileAssociation> notModifyProfileAssociations = getNotModifyProfileAssociations(profileAssociations, actionProfiles);
+
+    if (association.getMasterProfileType() == ProfileType.JOB_PROFILE && notModifyProfileAssociations.isEmpty()) {
+      LOGGER.warn("validateAddedModifyActionProfileAssociation:: Modify profile with id {}, used as standalone action", actionProfile.getId());
+      errors.add(new Error().withMessage(MODIFY_ACTION_CANNOT_BE_USED_AS_A_STANDALONE_ACTION));
+    }
+
+    if (association.getMasterProfileType() == MATCH_PROFILE && isFirstAtMatchBlock(profileAssociations, association)) {
+      LOGGER.warn("validateAddedModifyActionProfileAssociation:: Modify profile with id {}, used right after Match profile", actionProfile.getId());
+      errors.add(new Error().withMessage(MODIFY_ACTION_CANNOT_BE_USED_RIGHT_AFTER_THE_MATCH));
+    }
+  }
+
+  private static List<ProfileAssociation> getNotModifyProfileAssociations(List<ProfileAssociation> profileAssociations, List<ActionProfile> actionProfiles) {
+    List<String> modifyActionProfileIds = actionProfiles.stream().filter(a -> a.getAction() == ActionProfile.Action.MODIFY).map(ActionProfile::getId).toList();
+    return profileAssociations.stream().filter(p -> !modifyActionProfileIds.contains(p.getDetailProfileId())).toList();
+  }
+
+  private static boolean isFirstAtMatchBlock(List<ProfileAssociation> profileAssociations, ProfileAssociation association) {
+    if (association.getOrder() == 0) return true;
+    if (association.getMasterWrapperId() != null) {
+      List<ProfileAssociation> associationsAtMatchBlock = profileAssociations.stream()
+        .filter(a -> Objects.equals(a.getMasterWrapperId(), association.getMasterWrapperId())).toList();
+
+      ProfileAssociation associationWithLowestOrder = Collections.min(associationsAtMatchBlock,
+        Comparator.comparingInt(ProfileAssociation::getOrder));
+
+      return associationWithLowestOrder == association;
+    }
+    return false;
+  }
+
+  private Future<Errors> validateJobProfileLinkedMatchProfile(List<ProfileAssociation> profileAssociations,
+                                                              List<Error> errors, String tenantId) {
+    var childActionProfileAssociations = actionProfileAssociations(profileAssociations);
+    validateMatchProfilesAssociations(childActionProfileAssociations, errors);
+
+    var matchProfileAssociations = matchProfileAssociations(profileAssociations);
+    var matchProfileIds = matchProfileAssociations.stream().map(ProfileAssociation::getDetailProfileId).toList();
+
+    var futures = matchProfileIds.stream()
+      .map(id -> matchProfileService.getProfileById(id, false, tenantId))
+      .collect(Collectors.toList());
+
+    return GenericCompositeFuture.all(futures)
+      .compose(matchProfiles -> {
+        List<MatchProfile> existingMatchProfiles = matchProfiles.result().<Optional<MatchProfile>>list().stream()
+          .filter(Optional::isPresent).map(Optional::get).toList();
+
+        var existingMatchProfilesIds = existingMatchProfiles.stream().map(MatchProfile::getId).toList();
+        var notFoundIds = matchProfileIds.stream()
+          .filter(id -> !existingMatchProfilesIds.contains(id))
+          .map(notFoundedId -> String.format("'%s'", notFoundedId)).toList();
+
+        if (!notFoundIds.isEmpty()) {
+          var idStr = String.join(", ", notFoundIds);
+          LOGGER.warn("validateJobProfileLinkedMatchProfile:: Linked MatchProfiles with ids {} not founded", idStr);
+          return Future.failedFuture(new NotFoundException((String.format(LINKED_MATCH_PROFILES_WERE_NOT_FOUND, idStr))));
+        }
+        return Future.succeededFuture(new Errors().withErrors(errors).withTotalRecords(errors.size()));
+      });
+  }
+
+  private Future<Errors> validateMatchProfilesAssociations(List<ProfileAssociation> profileAssociations,
+                                                           List<Error> errors) {
+    LOGGER.debug("validateMatchProfilesAssociations:: Validating JobProfile if its MatchProfile contains ActionProfile");
+    if (CollectionUtils.isEmpty(profileAssociations)) {
+      LOGGER.warn("validateMatchProfilesAssociations:: Job profile does not contain any associations");
+      errors.add(new Error().withMessage("Linked ActionProfile was not found after MatchProfile"));
+    }
+    return Future.succeededFuture(new Errors().withErrors(errors).withTotalRecords(errors.size()));
+  }
+
+  private List<ProfileAssociation> matchProfileAssociations(List<ProfileAssociation> profileAssociations) {
+    return profileAssociations.stream()
+      .filter(profileAssociation -> profileAssociation.getDetailProfileType() == MATCH_PROFILE).toList();
+  }
 }

--- a/mod-di-converter-storage-server/src/main/java/org/folio/services/MappingProfileServiceImpl.java
+++ b/mod-di-converter-storage-server/src/main/java/org/folio/services/MappingProfileServiceImpl.java
@@ -1,30 +1,49 @@
 package org.folio.services;
 
 import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.json.jackson.DatabindCodec;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.okapi.common.GenericCompositeFuture;
 import org.folio.rest.impl.util.OkapiConnectionParams;
+import org.folio.rest.jaxrs.model.ActionProfile;
+import org.folio.rest.jaxrs.model.ActionProfileCollection;
+import org.folio.rest.jaxrs.model.ActionProfileUpdateDto;
+import org.folio.rest.jaxrs.model.Error;
+import org.folio.rest.jaxrs.model.Errors;
+import org.folio.rest.jaxrs.model.JobProfileUpdateDto;
 import org.folio.rest.jaxrs.model.MappingProfile;
 import org.folio.rest.jaxrs.model.MappingProfileCollection;
 import org.folio.rest.jaxrs.model.MappingProfileUpdateDto;
+import org.folio.rest.jaxrs.model.MappingRule;
+import org.folio.rest.jaxrs.model.OperationType;
 import org.folio.rest.jaxrs.model.ProfileAssociation;
 import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
 import org.folio.rest.jaxrs.model.ProfileType;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import javax.ws.rs.NotFoundException;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import static java.lang.String.format;
 import static org.folio.rest.jaxrs.model.ProfileType.ACTION_PROFILE;
 
 @Component
 public class MappingProfileServiceImpl extends AbstractProfileService<MappingProfile, MappingProfileCollection, MappingProfileUpdateDto> {
   private static final Logger LOGGER = LogManager.getLogger();
-
+  private static final String INVALID_RECORD_TYPE_LINKED_ACTION_PROFILE_TO_MAPPING_PROFILE = "Action profile '%s' can not be linked to this Mapping profile. FolioRecord and ExistingRecordType types are different";
+  private static final String INVALID_REPEATABLE_FIELD_ACTION_FOR_EMPTY_SUBFIELDS_MESSAGE = "Invalid repeatableFieldAction for empty subfields: %s";
+  private static final String INVALID_MAPPING_PROFILE_NEW_RECORD_TYPE_LINKED_TO_ACTION_PROFILE = "Can not update MappingProfile recordType and linked ActionProfile recordType are different";
   private static final List<String> DEFAULT_MAPPING_PROFILES = Arrays.asList(
     "d0ebbc2e-2f0f-11eb-adc1-0242ac120002", //OCLC_CREATE_MAPPING_PROFILE_ID
     "862000b9-84ea-4cae-a223-5fc0552f2b42", //OCLC_UPDATE_MAPPING_PROFILE_ID
@@ -37,7 +56,10 @@ public class MappingProfileServiceImpl extends AbstractProfileService<MappingPro
     "39b265e1-c963-4e5f-859d-6e8c327a265c", //DEFAULT_QM_MARC_BIB_UPDATE_MAPPING_PROFILE_ID
     "b8a9ca7d-4a33-44d3-86e1-f7c6cb7b265f", //DEFAULT_QM_HOLDINGS_UPDATE_MAPPING_PROFILE_ID
     "041f8ff9-9d17-4436-b305-1033e0879501" //DEFAULT_QM_AUTHORITY_UPDATE_MAPPING_PROFILE_ID
-    );
+  );
+
+  @Autowired
+  private ProfileService<ActionProfile, ActionProfileCollection, ActionProfileUpdateDto> actionProfileService;
 
   @Override
   public Future<MappingProfile> saveProfile(MappingProfileUpdateDto profileDto, OkapiConnectionParams params) {
@@ -137,6 +159,15 @@ public class MappingProfileServiceImpl extends AbstractProfileService<MappingPro
     return DEFAULT_MAPPING_PROFILES;
   }
 
+  @Override
+  protected Future<Errors> validateProfile(OperationType operationType, MappingProfileUpdateDto profileDto, String tenantId) {
+    return composeFutureErrors(
+      validateMappingProfileAddedRelationsFolioRecord(profileDto, tenantId),
+      validateMappingProfile(operationType, profileDto, tenantId),
+      operationType == OperationType.UPDATE ? validateMappingProfileExistProfilesFolioRecord(profileDto, tenantId) : Future.succeededFuture(new Errors())
+    );
+  }
+
   private Future<Boolean> deleteExistingActionToMappingAssociations(MappingProfileUpdateDto profileDto, String tenantId) {
     List<Future<Boolean>> futures = profileDto.getAddedRelations().stream()
       .filter(profileAssociation -> profileAssociation.getMasterProfileType().equals(ACTION_PROFILE))
@@ -146,8 +177,86 @@ public class MappingProfileServiceImpl extends AbstractProfileService<MappingPro
       .collect(Collectors.toList());
 
     return GenericCompositeFuture.all(futures)
-      .onFailure(th -> LOGGER.warn( "deleteExistingActionToMappingAssociations:: Failed to delete existing action-to-mapping associations", th))
+      .onFailure(th -> LOGGER.warn("deleteExistingActionToMappingAssociations:: Failed to delete existing action-to-mapping associations", th))
       .map(true);
   }
 
+  private Future<Errors> validateMappingProfileAddedRelationsFolioRecord(MappingProfileUpdateDto mappingProfileUpdateDto, String tenantId) {
+    if (CollectionUtils.isEmpty(mappingProfileUpdateDto.getAddedRelations())) {
+      return Future.succeededFuture(new Errors().withTotalRecords(0));
+    }
+
+    var errors = new LinkedList<Error>();
+    Promise<Errors> promise = Promise.promise();
+
+    var futures = mappingProfileUpdateDto
+      .getAddedRelations()
+      .stream()
+      .filter(profileAssociation -> profileAssociation.getMasterProfileType() == ACTION_PROFILE)
+      .map(profileAssociation -> actionProfileService.getProfileById(profileAssociation.getMasterProfileId(), false, tenantId))
+      .map(futureActionProfile -> futureActionProfile.onSuccess(optionalActionProfile ->
+        optionalActionProfile.ifPresent(actionProfile -> validateAssociations(actionProfile, mappingProfileUpdateDto.getProfile(), errors,
+          String.format(INVALID_RECORD_TYPE_LINKED_ACTION_PROFILE_TO_MAPPING_PROFILE, actionProfile.getName())))
+      ))
+      .collect(Collectors.toList());
+    GenericCompositeFuture.all(futures)
+      .onSuccess(handler -> promise.complete(new Errors().withErrors(errors)))
+      .onFailure(promise::fail);
+
+    return promise.future();
+  }
+
+  private Future<Errors> validateMappingProfile(OperationType operationType, MappingProfileUpdateDto mappingProfileUpdateDto, String tenantId) {
+    MappingProfile mappingProfile = mappingProfileUpdateDto.getProfile();
+    return super.validateProfile(operationType, mappingProfileUpdateDto, tenantId)
+      .map(errors -> {
+        List<Error> fieldsValidationErrors = validateRepeatableFields(mappingProfile);
+        errors.withTotalRecords(errors.getTotalRecords() + fieldsValidationErrors.size())
+          .getErrors().addAll(fieldsValidationErrors);
+        return errors;
+      });
+  }
+
+  private Future<Errors> validateMappingProfileExistProfilesFolioRecord(MappingProfileUpdateDto mappingProfileUpdateDto, String tenantId) {
+    String profileId = mappingProfileUpdateDto.getProfile().getId();
+    var errors = new LinkedList<Error>();
+    var deletedRelations = mappingProfileUpdateDto.getDeletedRelations();
+    Promise<Errors> promise = Promise.promise();
+
+    getProfileById(profileId, true, tenantId)
+      .onSuccess(optionalMappingProfile ->
+        optionalMappingProfile.ifPresentOrElse(mappingProfile -> {
+            var existActionProfiles = CollectionUtils.isEmpty(deletedRelations) ? mappingProfile.getParentProfiles() :
+              mappingProfile.getParentProfiles().stream()
+                .filter(profileSnapshotWrapper -> profileSnapshotWrapper.getContentType() == ACTION_PROFILE)
+                .filter(profileSnapshotWrapper -> deletedRelations.stream()
+                  .noneMatch(deletedRelation -> Objects.equals(deletedRelation.getMasterProfileId(), profileSnapshotWrapper.getProfileId())))
+                .toList();
+
+            existActionProfiles.forEach(actionWrapper -> {
+              var actionProfile = DatabindCodec.mapper().convertValue(actionWrapper.getContent(), ActionProfile.class);
+              validateAssociations(actionProfile, mappingProfileUpdateDto.getProfile(), errors, INVALID_MAPPING_PROFILE_NEW_RECORD_TYPE_LINKED_TO_ACTION_PROFILE);
+            });
+            promise.complete(new Errors().withErrors(errors));
+          }, () -> promise.fail(new NotFoundException(String.format("Mapping profile with id '%s' was not found", profileId)))
+        )
+      )
+      .onFailure(promise::fail);
+
+    return promise.future();
+  }
+
+  private List<Error> validateRepeatableFields(MappingProfile mappingProfile) {
+    List<Error> errorList = new ArrayList<>();
+    if (mappingProfile.getMappingDetails() != null && mappingProfile.getMappingDetails().getMappingFields() != null) {
+      List<MappingRule> mappingFields = mappingProfile.getMappingDetails().getMappingFields();
+      for (MappingRule rule : mappingFields) {
+        if (rule.getRepeatableFieldAction() != null && rule.getSubfields().isEmpty() &&
+          !rule.getRepeatableFieldAction().equals(MappingRule.RepeatableFieldAction.DELETE_EXISTING)) {
+          errorList.add(new Error().withMessage(format(INVALID_REPEATABLE_FIELD_ACTION_FOR_EMPTY_SUBFIELDS_MESSAGE, rule.getRepeatableFieldAction())));
+        }
+      }
+    }
+    return errorList;
+  }
 }

--- a/mod-di-converter-storage-server/src/main/java/org/folio/services/MappingProfileServiceImpl.java
+++ b/mod-di-converter-storage-server/src/main/java/org/folio/services/MappingProfileServiceImpl.java
@@ -14,7 +14,6 @@ import org.folio.rest.jaxrs.model.ActionProfileCollection;
 import org.folio.rest.jaxrs.model.ActionProfileUpdateDto;
 import org.folio.rest.jaxrs.model.Error;
 import org.folio.rest.jaxrs.model.Errors;
-import org.folio.rest.jaxrs.model.JobProfileUpdateDto;
 import org.folio.rest.jaxrs.model.MappingProfile;
 import org.folio.rest.jaxrs.model.MappingProfileCollection;
 import org.folio.rest.jaxrs.model.MappingProfileUpdateDto;
@@ -198,7 +197,7 @@ public class MappingProfileServiceImpl extends AbstractProfileService<MappingPro
         optionalActionProfile.ifPresent(actionProfile -> validateAssociations(actionProfile, mappingProfileUpdateDto.getProfile(), errors,
           String.format(INVALID_RECORD_TYPE_LINKED_ACTION_PROFILE_TO_MAPPING_PROFILE, actionProfile.getName())))
       ))
-      .collect(Collectors.toList());
+      .toList();
     GenericCompositeFuture.all(futures)
       .onSuccess(handler -> promise.complete(new Errors().withErrors(errors)))
       .onFailure(promise::fail);

--- a/mod-di-converter-storage-server/src/main/java/org/folio/services/MappingProfileServiceImpl.java
+++ b/mod-di-converter-storage-server/src/main/java/org/folio/services/MappingProfileServiceImpl.java
@@ -22,8 +22,21 @@ import static org.folio.rest.jaxrs.model.ProfileType.ACTION_PROFILE;
 
 @Component
 public class MappingProfileServiceImpl extends AbstractProfileService<MappingProfile, MappingProfileCollection, MappingProfileUpdateDto> {
-
   private static final Logger LOGGER = LogManager.getLogger();
+
+  private static final String[] DEFAULT_MAPPING_PROFILES = {
+    "d0ebbc2e-2f0f-11eb-adc1-0242ac120002", //OCLC_CREATE_MAPPING_PROFILE_ID
+    "862000b9-84ea-4cae-a223-5fc0552f2b42", //OCLC_UPDATE_MAPPING_PROFILE_ID
+    "f90864ef-8030-480f-a43f-8cdd21233252", //OCLC_UPDATE_MARC_BIB_MAPPING_PROFILE_ID
+    "991c0300-44a6-47e3-8ea2-b01bb56a38cc", //DEFAULT_CREATE_DERIVE_INSTANCE_MAPPING_PROFILE_ID
+    "e0fbaad5-10c0-40d5-9228-498b351dbbaa", //DEFAULT_CREATE_DERIVE_HOLDINGS_MAPPING_PROFILE_ID
+    "13cf7adf-c7a7-4c2e-838f-14d0ac36ec0a", //DEFAULT_CREATE_HOLDINGS_MAPPING_PROFILE_ID
+    "6a0ec1de-68eb-4833-bdbf-0741db25c314", //DEFAULT_CREATE_AUTHORITIES_MAPPING_PROFILE_ID
+    "6a0ec1de-68eb-4833-bdbf-0741db85c314", //DEFAULT_CREATE_AUTHORITY_MAPPING_PROFILE_ID
+    "39b265e1-c963-4e5f-859d-6e8c327a265c", //DEFAULT_QM_MARC_BIB_UPDATE_MAPPING_PROFILE_ID
+    "b8a9ca7d-4a33-44d3-86e1-f7c6cb7b265f", //DEFAULT_QM_HOLDINGS_UPDATE_MAPPING_PROFILE_ID
+    "041f8ff9-9d17-4436-b305-1033e0879501" //DEFAULT_QM_AUTHORITY_UPDATE_MAPPING_PROFILE_ID
+  };
 
   @Override
   public Future<MappingProfile> saveProfile(MappingProfileUpdateDto profileDto, OkapiConnectionParams params) {
@@ -45,9 +58,9 @@ public class MappingProfileServiceImpl extends AbstractProfileService<MappingPro
   }
 
   @Override
-  Future<MappingProfile> setUserInfoForProfile(MappingProfileUpdateDto profile, OkapiConnectionParams params) {
-    return lookupUser(profile.getProfile().getMetadata().getUpdatedByUserId(), params)
-      .compose(userInfo -> Future.succeededFuture(profile.getProfile().withUserInfo(userInfo)));
+  Future<MappingProfile> setUserInfoForProfile(MappingProfile profile, OkapiConnectionParams params) {
+    return lookupUser(profile.getMetadata().getUpdatedByUserId(), params)
+      .compose(userInfo -> Future.succeededFuture(profile.withUserInfo(userInfo)));
   }
 
   @Override
@@ -116,6 +129,11 @@ public class MappingProfileServiceImpl extends AbstractProfileService<MappingPro
   @Override
   protected MappingProfile getProfile(MappingProfileUpdateDto dto) {
     return dto.getProfile();
+  }
+
+  @Override
+  protected String[] getDefaultProfiles() {
+    return DEFAULT_MAPPING_PROFILES;
   }
 
   private Future<Boolean> deleteExistingActionToMappingAssociations(MappingProfileUpdateDto profileDto, String tenantId) {

--- a/mod-di-converter-storage-server/src/main/java/org/folio/services/MappingProfileServiceImpl.java
+++ b/mod-di-converter-storage-server/src/main/java/org/folio/services/MappingProfileServiceImpl.java
@@ -14,6 +14,7 @@ import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
 import org.folio.rest.jaxrs.model.ProfileType;
 import org.springframework.stereotype.Component;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -24,7 +25,7 @@ import static org.folio.rest.jaxrs.model.ProfileType.ACTION_PROFILE;
 public class MappingProfileServiceImpl extends AbstractProfileService<MappingProfile, MappingProfileCollection, MappingProfileUpdateDto> {
   private static final Logger LOGGER = LogManager.getLogger();
 
-  private static final String[] DEFAULT_MAPPING_PROFILES = {
+  private static final List<String> DEFAULT_MAPPING_PROFILES = Arrays.asList(
     "d0ebbc2e-2f0f-11eb-adc1-0242ac120002", //OCLC_CREATE_MAPPING_PROFILE_ID
     "862000b9-84ea-4cae-a223-5fc0552f2b42", //OCLC_UPDATE_MAPPING_PROFILE_ID
     "f90864ef-8030-480f-a43f-8cdd21233252", //OCLC_UPDATE_MARC_BIB_MAPPING_PROFILE_ID
@@ -36,7 +37,7 @@ public class MappingProfileServiceImpl extends AbstractProfileService<MappingPro
     "39b265e1-c963-4e5f-859d-6e8c327a265c", //DEFAULT_QM_MARC_BIB_UPDATE_MAPPING_PROFILE_ID
     "b8a9ca7d-4a33-44d3-86e1-f7c6cb7b265f", //DEFAULT_QM_HOLDINGS_UPDATE_MAPPING_PROFILE_ID
     "041f8ff9-9d17-4436-b305-1033e0879501" //DEFAULT_QM_AUTHORITY_UPDATE_MAPPING_PROFILE_ID
-  };
+    );
 
   @Override
   public Future<MappingProfile> saveProfile(MappingProfileUpdateDto profileDto, OkapiConnectionParams params) {
@@ -132,7 +133,7 @@ public class MappingProfileServiceImpl extends AbstractProfileService<MappingPro
   }
 
   @Override
-  protected String[] getDefaultProfiles() {
+  protected List<String> getDefaultProfiles() {
     return DEFAULT_MAPPING_PROFILES;
   }
 

--- a/mod-di-converter-storage-server/src/main/java/org/folio/services/MatchProfileServiceImpl.java
+++ b/mod-di-converter-storage-server/src/main/java/org/folio/services/MatchProfileServiceImpl.java
@@ -11,19 +11,20 @@ import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
 import org.folio.rest.jaxrs.model.ProfileType;
 import org.springframework.stereotype.Component;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 
 @Component
 public class MatchProfileServiceImpl extends AbstractProfileService<MatchProfile, MatchProfileCollection, MatchProfileUpdateDto> {
-  private static final String[] DEFAULT_MATCH_PROFILES = {
+  private static final List<String> DEFAULT_MATCH_PROFILES = Arrays.asList(
     "d27d71ce-8a1e-44c6-acea-96961b5592c6", //OCLC_MARC_MARC_MATCH_PROFILE_ID
     "31dbb554-0826-48ec-a0a4-3c55293d4dee", //OCLC_INSTANCE_UUID_MATCH_PROFILE_ID
     "4be5d1d2-1f5a-42ff-a9bd-fc90609d94b6",  //DEFAULT_DELETE_MARC_AUTHORITY_MATCH_PROFILE_ID
     "91cec42a-260d-4a8c-a9fb-90d9435ca2f4", //DEFAULT_QM_MARC_BIB_UPDATE_MATCH_PROFILE_ID
     "2a599369-817f-4fe8-bae2-f3e3987990fe", //DEFAULT_QM_HOLDINGS_UPDATE_MATCH_PROFILE_ID
     "aff72eae-847c-4a97-b7b9-c1ddb8cdcbbf"  //DEFAULT_QM_AUTHORITY_UPDATE_MATCH_PROFILE_ID
-  };
+    );
 
   @Override
   MatchProfile setProfileId(MatchProfile profile) {
@@ -107,7 +108,7 @@ public class MatchProfileServiceImpl extends AbstractProfileService<MatchProfile
   }
 
   @Override
-  protected String[] getDefaultProfiles() {
+  protected List<String> getDefaultProfiles() {
     return DEFAULT_MATCH_PROFILES;
   }
 }

--- a/mod-di-converter-storage-server/src/main/java/org/folio/services/MatchProfileServiceImpl.java
+++ b/mod-di-converter-storage-server/src/main/java/org/folio/services/MatchProfileServiceImpl.java
@@ -16,6 +16,14 @@ import java.util.UUID;
 
 @Component
 public class MatchProfileServiceImpl extends AbstractProfileService<MatchProfile, MatchProfileCollection, MatchProfileUpdateDto> {
+  private static final String[] DEFAULT_MATCH_PROFILES = {
+    "d27d71ce-8a1e-44c6-acea-96961b5592c6", //OCLC_MARC_MARC_MATCH_PROFILE_ID
+    "31dbb554-0826-48ec-a0a4-3c55293d4dee", //OCLC_INSTANCE_UUID_MATCH_PROFILE_ID
+    "4be5d1d2-1f5a-42ff-a9bd-fc90609d94b6",  //DEFAULT_DELETE_MARC_AUTHORITY_MATCH_PROFILE_ID
+    "91cec42a-260d-4a8c-a9fb-90d9435ca2f4", //DEFAULT_QM_MARC_BIB_UPDATE_MATCH_PROFILE_ID
+    "2a599369-817f-4fe8-bae2-f3e3987990fe", //DEFAULT_QM_HOLDINGS_UPDATE_MATCH_PROFILE_ID
+    "aff72eae-847c-4a97-b7b9-c1ddb8cdcbbf"  //DEFAULT_QM_AUTHORITY_UPDATE_MATCH_PROFILE_ID
+  };
 
   @Override
   MatchProfile setProfileId(MatchProfile profile) {
@@ -25,9 +33,9 @@ public class MatchProfileServiceImpl extends AbstractProfileService<MatchProfile
   }
 
   @Override
-  Future<MatchProfile> setUserInfoForProfile(MatchProfileUpdateDto profile, OkapiConnectionParams params) {
-    return lookupUser(profile.getProfile().getMetadata().getUpdatedByUserId(), params)
-      .compose(userInfo -> Future.succeededFuture(profile.getProfile().withUserInfo(userInfo)));
+  Future<MatchProfile> setUserInfoForProfile(MatchProfile profile, OkapiConnectionParams params) {
+    return lookupUser(profile.getMetadata().getUpdatedByUserId(), params)
+      .compose(userInfo -> Future.succeededFuture(profile.withUserInfo(userInfo)));
   }
 
   @Override
@@ -98,4 +106,8 @@ public class MatchProfileServiceImpl extends AbstractProfileService<MatchProfile
     return dto.getProfile();
   }
 
+  @Override
+  protected String[] getDefaultProfiles() {
+    return DEFAULT_MATCH_PROFILES;
+  }
 }

--- a/mod-di-converter-storage-server/src/main/java/org/folio/services/ProfileService.java
+++ b/mod-di-converter-storage-server/src/main/java/org/folio/services/ProfileService.java
@@ -40,7 +40,7 @@ public interface ProfileService<T, S, D> {
   /**
    * Saves T entity
    *
-   * @param profile Profile to save
+   * @param profileDto Profile DTO to save
    * @param params  {@link OkapiConnectionParams}
    * @return future with saved entity
    */
@@ -49,7 +49,7 @@ public interface ProfileService<T, S, D> {
   /**
    * Updates D with given id
    *
-   * @param profile Profile to update
+   * @param profileDto Profile DTO to update
    * @param params  {@link OkapiConnectionParams}
    * @return future with updated entity
    */
@@ -72,17 +72,6 @@ public interface ProfileService<T, S, D> {
    * @return - boolean value. True if job profile with the same id already exist
    */
   Future<Boolean> isProfileExistByProfileId(T profile, String tenantId);
-
-  /**
-   * Check profile to access another fields except tags
-   *
-   * @param id               - Profile id
-   * @param profile          - D DTO
-   * @param isDefaultProfile - True if the profile lists as default
-   * @param tenantId         - Tenant id from request
-   * @return - boolean value. True if in the profile DTO has been changed only Tags
-   */
-  Future<Boolean> isProfileDtoValidForUpdate(String id, D profile, boolean isDefaultProfile, String tenantId);
 
   /**
    * Hard deletes profile by its id

--- a/mod-di-converter-storage-server/src/main/java/org/folio/services/ProfileService.java
+++ b/mod-di-converter-storage-server/src/main/java/org/folio/services/ProfileService.java
@@ -44,7 +44,7 @@ public interface ProfileService<T, S, D> {
    * @param params  {@link OkapiConnectionParams}
    * @return future with saved entity
    */
-  Future<T> saveProfile(D profile, OkapiConnectionParams params);
+  Future<T> saveProfile(D profileDto, OkapiConnectionParams params);
 
   /**
    * Updates D with given id
@@ -53,7 +53,7 @@ public interface ProfileService<T, S, D> {
    * @param params  {@link OkapiConnectionParams}
    * @return future with updated entity
    */
-  Future<T> updateProfile(D profile, OkapiConnectionParams params);
+  Future<T> updateProfile(D profileDto, OkapiConnectionParams params);
 
   /**
    * Search in database profile with the same name which contains in specified profile

--- a/mod-di-converter-storage-server/src/main/java/org/folio/services/exception/UnprocessableEntityException.java
+++ b/mod-di-converter-storage-server/src/main/java/org/folio/services/exception/UnprocessableEntityException.java
@@ -1,0 +1,18 @@
+package org.folio.services.exception;
+
+import org.folio.rest.jaxrs.model.Errors;
+
+/**
+ * A runtime exception indicating a request contains invalid body.
+ */
+public class UnprocessableEntityException extends RuntimeException {
+  private final Errors errors;
+
+  public UnprocessableEntityException(Errors errors) {
+    this.errors = errors;
+  }
+
+  public Errors getErrors() {
+    return errors;
+  }
+}

--- a/mod-di-converter-storage-server/src/main/java/org/folio/services/exception/UnprocessableEntityException.java
+++ b/mod-di-converter-storage-server/src/main/java/org/folio/services/exception/UnprocessableEntityException.java
@@ -6,7 +6,7 @@ import org.folio.rest.jaxrs.model.Errors;
  * A runtime exception indicating a request contains invalid body.
  */
 public class UnprocessableEntityException extends RuntimeException {
-  private final Errors errors;
+  private transient final Errors errors;
 
   public UnprocessableEntityException(Errors errors) {
     this.errors = errors;

--- a/mod-di-converter-storage-server/src/main/java/org/folio/services/exception/UnprocessableEntityException.java
+++ b/mod-di-converter-storage-server/src/main/java/org/folio/services/exception/UnprocessableEntityException.java
@@ -6,7 +6,7 @@ import org.folio.rest.jaxrs.model.Errors;
  * A runtime exception indicating a request contains invalid body.
  */
 public class UnprocessableEntityException extends RuntimeException {
-  private transient final Errors errors;
+  private final transient Errors errors;
 
   public UnprocessableEntityException(Errors errors) {
     this.errors = errors;


### PR DESCRIPTION
## Purpose
Refactor data import profiles controller to not contain profile validation 
## Approach
Move data import profile validation to service layer

## Learning
Jira: https://folio-org.atlassian.net/browse/MODDICONV-390