### PR TITLE
MODDICONV-399: Upgrade Spring from 5.3.23 to 6.1.13

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 * [MODDICONV-312](https://folio-org.atlassian.net/browse/MODDICONV-312) Create general associations table
 * [MODDICONV-373](https://folio-org.atlassian.net/browse/MODDICONV-373) Disallow create/update of a job profile without actions
 * [MODDICONV-391](https://issues.folio.org/browse/MODDICONV-391) Create migration script for Order mapping profiles
+* [MODDICONV-399](https://folio-org.atlassian.net/browse/MODDICONV-399) Upgrade Spring from 5.3.23 to 6.1.13
 
 ## 2024-03-20 2.2.0
 * [MODDICORE-398](https://folio-org.atlassian.net/browse/MODDICORE-398) Upgrade mod-di-converter-storage to RMB 35.2.0, Vert.x 4.5.4

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <sonar.exclusions>**/ModTenantAPI.java</sonar.exclusions>
     <testcontainers.version>1.19.7</testcontainers.version>
-    <spring.version>5.3.32</spring.version>
+    <spring.version>6.1.13</spring.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODDICONV-399

## Purpose
Spring 5.3.x has been out of support since 2024-08-31: https://spring.io/projects/spring-framework#support

We need a supported version to get security fixes.

## Approach
Upgrade Spring from 5.3.23 to 6.1.13, the latest released version.