### PR TITLE
MODDICONV-403 mod-di-converter-storage Ramsons 2024 R2 - RMB v35.3.x update

### DIFF
--- a/.github/workflows/postgres.yml
+++ b/.github/workflows/postgres.yml
@@ -1,0 +1,26 @@
+name: postgres
+on:
+  workflow_dispatch:
+    inputs:
+      postgres:
+        description: "List of postgres container images, to be injected as TESTCONTAINERS_POSTGRES_IMAGE"
+        default: '["postgres:16-alpine", "postgres:18-alpine"]'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        postgres: ${{ fromJSON(github.event.inputs.postgres) }}
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: maven
+      - run: mvn --batch-mode verify
+        env:
+          TESTCONTAINERS_POSTGRES_IMAGE: ${{ matrix.postgres }}

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 * [MODDICONV-391](https://issues.folio.org/browse/MODDICONV-391) Create migration script for Order mapping profiles
 * [MODDICONV-399](https://folio-org.atlassian.net/browse/MODDICONV-399) Upgrade Spring from 5.3.23 to 6.1.13
 * [MODDICONV-396](https://folio-org.atlassian.net/browse/MODDICONV-396) Remove accepted values from Instance, Holdings, Items and Orders mapping profiles
+* [MODDICONV-403](https://folio-org.atlassian.net/browse/MODDICONV-403) mod-di-converter-storage Ramsons 2024 R2 - RMB v35.3.x update
 
 ## 2024-03-20 2.2.0
 * [MODDICORE-398](https://folio-org.atlassian.net/browse/MODDICORE-398) Upgrade mod-di-converter-storage to RMB 35.2.0, Vert.x 4.5.4

--- a/pom.xml
+++ b/pom.xml
@@ -20,8 +20,8 @@
   </modules>
 
   <properties>
-    <raml-module-builder.version>35.2.0</raml-module-builder.version>
-    <vertx.version>4.5.4</vertx.version>
+    <raml-module-builder.version>35.3.0</raml-module-builder.version>
+    <vertx.version>4.5.7</vertx.version>
     <junit.version>4.13.2</junit.version>
     <mockito.version>5.1.1</mockito.version>
     <rest-assured.version>4.5.1</rest-assured.version>


### PR DESCRIPTION
## Purpose
[MODDICONV-403](https://folio-org.atlassian.net/browse/MODDICONV-403) mod-di-converter-storage Ramsons 2024 R2 - RMB v35.3.x update

## Approach
Upgrade to RMB v35.3

Follow the [RMB upgrade notes for 35.3.x](https://github.com/folio-org/raml-module-builder/releases/tag/v35.3.0) upgrade.

Upgrade Vertx to 4.5.7 version.

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

## Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
