### PR TITLE
MODDICONV-394 Disallow usage of Update MARC Bib next to Update Instance actions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 * [MODDICONV-393](https://folio-org.atlassian.net/browse/MODDICONV-393) Fix inconsistencies in permission namings
 * [MODDICONV-396](https://folio-org.atlassian.net/browse/MODDICONV-396) Remove accepted values from Instance, Holdings, Items and Orders mapping profiles
 * [MODDICONV-403](https://folio-org.atlassian.net/browse/MODDICONV-403) mod-di-converter-storage Ramsons 2024 R2 - RMB v35.3.x update
+* [MODDICONV-394](https://folio-org.atlassian.net/browse/MODDICONV-394) Disallow usage of Update MARC Bib next to Update Instance actions
 
 ## 2024-03-20 2.2.0
 * [MODDICORE-398](https://folio-org.atlassian.net/browse/MODDICORE-398) Upgrade mod-di-converter-storage to RMB 35.2.0, Vert.x 4.5.4

--- a/mod-di-converter-storage-server/src/main/java/org/folio/services/JobProfileServiceImpl.java
+++ b/mod-di-converter-storage-server/src/main/java/org/folio/services/JobProfileServiceImpl.java
@@ -379,7 +379,7 @@ public class JobProfileServiceImpl extends AbstractProfileService<JobProfile, Jo
   }
 
   private static Predicate<ActionProfile> isUpdateMarcBibOrInstanceAction() {
-    return (ap) -> ap.getAction() == UPDATE &&
+    return ap -> ap.getAction() == UPDATE &&
                   (ap.getFolioRecord().equals(MARC_BIBLIOGRAPHIC) || ap.getFolioRecord().equals(INSTANCE));
   }
 

--- a/mod-di-converter-storage-server/src/main/java/org/folio/services/JobProfileServiceImpl.java
+++ b/mod-di-converter-storage-server/src/main/java/org/folio/services/JobProfileServiceImpl.java
@@ -241,7 +241,8 @@ public class JobProfileServiceImpl extends AbstractProfileService<JobProfile, Jo
   private List<ProfileAssociation> filterProfileAssociations(List<ProfileAssociation> profileAssociations) {
     return profileAssociations.stream()
       .filter(profileAssociation -> profileAssociation.getDetailProfileType() != ProfileType.MAPPING_PROFILE &&
-        profileAssociation.getDetailProfileType() != ProfileType.JOB_PROFILE).toList();
+        profileAssociation.getDetailProfileType() != ProfileType.JOB_PROFILE)
+      .collect(Collectors.toList());
   }
 
   private List<ProfileAssociation> removeDeletedProfileAssociations(List<ProfileAssociation> profileAssociations,

--- a/mod-di-converter-storage-server/src/test/java/org/folio/rest/impl/JobProfileTest.java
+++ b/mod-di-converter-storage-server/src/test/java/org/folio/rest/impl/JobProfileTest.java
@@ -1002,6 +1002,133 @@ public class JobProfileTest extends AbstractRestVerticleTest {
   }
 
   @Test
+  public void shouldReturnBadRequestOnPostWhenUpdateBibAndInstanceUnderSameMatch() {
+    var instanceMappingProfileId = UUID.randomUUID().toString();
+    var bibMappingProfileId = UUID.randomUUID().toString();
+    var bibActionProfileId = UUID.randomUUID().toString();
+    var instanceActionProfileId = UUID.randomUUID().toString();
+    var matchProfileId = UUID.randomUUID().toString();
+    var jobId = UUID.randomUUID().toString();
+
+    RestAssured.given()
+      .spec(spec)
+      .body(new MatchProfileUpdateDto()
+        .withProfile(new MatchProfile()
+          .withId(matchProfileId)
+          .withName("testMatch")
+          .withIncomingRecordType(EntityType.MARC_BIBLIOGRAPHIC)
+          .withExistingRecordType(EntityType.INSTANCE)))
+      .when()
+      .post(MATCH_PROFILES_PATH);
+
+    RestAssured.given()
+      .spec(spec)
+      .body(new ActionProfileUpdateDto()
+        .withProfile(new ActionProfile().withName("update bib")
+          .withAction(UPDATE)
+          .withFolioRecord(MARC_BIBLIOGRAPHIC)
+          .withId(bibActionProfileId)))
+      .when()
+      .post(ACTION_PROFILES_PATH)
+      .then()
+      .statusCode(HttpStatus.SC_CREATED);
+
+    RestAssured.given()
+      .spec(spec)
+      .body(new ActionProfileUpdateDto()
+        .withProfile(new ActionProfile().withName("update instance")
+          .withAction(UPDATE)
+          .withFolioRecord(INSTANCE)
+          .withId(instanceActionProfileId)))
+      .when()
+      .post(ACTION_PROFILES_PATH)
+      .then()
+      .statusCode(HttpStatus.SC_CREATED);
+
+
+    RestAssured.given()
+      .spec(spec)
+      .body(new MappingProfileUpdateDto()
+        .withProfile(new MappingProfile().withName("updateInstance")
+          .withId(instanceMappingProfileId)
+          .withIncomingRecordType(EntityType.MARC_BIBLIOGRAPHIC)
+          .withExistingRecordType(EntityType.INSTANCE))
+        .withAddedRelations(
+          List.of(
+            new ProfileAssociation()
+              .withMasterProfileId(instanceActionProfileId)
+              .withDetailProfileId(instanceMappingProfileId)
+              .withMasterProfileType(ACTION_PROFILE)
+              .withDetailProfileType(ProfileType.MAPPING_PROFILE)
+              .withOrder(0))))
+      .when()
+      .post(MAPPING_PROFILES_PATH)
+      .then()
+      .statusCode(HttpStatus.SC_CREATED)
+      .extract().as(MappingProfileUpdateDto.class);
+
+    RestAssured.given()
+      .spec(spec)
+      .body(new MappingProfileUpdateDto()
+        .withProfile(new MappingProfile().withName("updateBib")
+          .withId(bibMappingProfileId)
+          .withIncomingRecordType(EntityType.MARC_BIBLIOGRAPHIC)
+          .withExistingRecordType(EntityType.MARC_BIBLIOGRAPHIC))
+        .withAddedRelations(
+          List.of(
+            new ProfileAssociation()
+              .withMasterProfileId(bibActionProfileId)
+              .withDetailProfileId(bibMappingProfileId)
+              .withMasterProfileType(ACTION_PROFILE)
+              .withDetailProfileType(ProfileType.MAPPING_PROFILE)
+              .withOrder(0))))
+      .when()
+      .post(MAPPING_PROFILES_PATH)
+      .then()
+      .statusCode(HttpStatus.SC_CREATED)
+      .extract().as(MappingProfileUpdateDto.class);
+
+
+    var invalidAssociationInstanceActionToMatch = new ProfileAssociation()
+      .withDetailProfileType(ACTION_PROFILE)
+      .withDetailProfileId(instanceActionProfileId)
+      .withMasterProfileType(MATCH_PROFILE)
+      .withMasterProfileId(matchProfileId)
+      .withReactTo(MATCH);
+
+    var invalidAssociationBibActionToMatch = new ProfileAssociation()
+      .withDetailProfileType(ACTION_PROFILE)
+      .withDetailProfileId(bibActionProfileId)
+      .withMasterProfileType(MATCH_PROFILE)
+      .withMasterProfileId(matchProfileId)
+      .withReactTo(MATCH);
+
+    var invalidAssociationMatchToJobProfile = new ProfileAssociation()
+      .withDetailProfileType(MATCH_PROFILE)
+      .withDetailProfileId(matchProfileId)
+      .withMasterProfileType(JOB_PROFILE)
+      .withMasterProfileId(jobId);
+
+    RestAssured.given()
+      .spec(spec)
+      .body(new JobProfileUpdateDto()
+        .withProfile(new JobProfile()
+          .withId(jobId)
+          .withName("testJob")
+          .withDataType(MARC))
+        .withAddedRelations(List.of(invalidAssociationMatchToJobProfile, invalidAssociationBibActionToMatch, invalidAssociationInstanceActionToMatch))
+      )
+      .when()
+      .post(JOB_PROFILES_PATH)
+      .then()
+      .statusCode(HttpStatus.SC_UNPROCESSABLE_ENTITY)
+      .body("errors", hasItem(
+        hasEntry(is("message"),
+          is("More than two update actions cannot be placed under the same match block"))
+      ));
+  }
+
+  @Test
   public void shouldReturnNotFoundOnPostJobProfileWithInvalidLinkedProfiles() {
     var actionProfileId = UUID.randomUUID().toString();
     var matchProfileId = UUID.randomUUID().toString();

--- a/mod-di-converter-storage-server/src/test/java/org/folio/rest/impl/JobProfileTest.java
+++ b/mod-di-converter-storage-server/src/test/java/org/folio/rest/impl/JobProfileTest.java
@@ -1124,7 +1124,7 @@ public class JobProfileTest extends AbstractRestVerticleTest {
       .statusCode(HttpStatus.SC_UNPROCESSABLE_ENTITY)
       .body("errors", hasItem(
         hasEntry(is("message"),
-          is("More than two update actions cannot be placed under the same match block"))
+          is("Update MARC Bib and Update Instance actions cannot be placed under the same match block"))
       ));
   }
 


### PR DESCRIPTION
## Purpose
[MODDICONV-394](https://folio-org.atlassian.net/browse/MODDICONV-394) Disallow usage of Update MARC Bib next to Update Instance actions

## Approach
* add validation layer
* add tests

![image](https://github.com/user-attachments/assets/fbc5ec46-572d-49ad-b354-e49bc44de7c2)
