### PR TITLE
MODDICONV-418 - Added script to fix order mapping profiles

### DIFF
--- a/mod-di-converter-storage-server/src/main/resources/templates/db_scripts/data-migration/fix_order_mapping_profiles.sql
+++ b/mod-di-converter-storage-server/src/main/resources/templates/db_scripts/data-migration/fix_order_mapping_profiles.sql
@@ -1,0 +1,11 @@
+-- removes redundant mapping for "donorOrganizationIds" field that might have been added
+-- due to the repeated execution of the corresponding script for adding this mapping
+WITH profiles_ids AS (
+  SELECT id
+  FROM ${myuniversity}_${mymodule}.mapping_profiles
+  WHERE jsonb -> 'mappingDetails' ->> 'recordType' = 'ORDER'
+    AND jsonb_array_length(jsonb_path_query_array(jsonb, '$.mappingDetails.mappingFields[*] ? (@.name == "donorOrganizationIds")')) > 1
+)
+UPDATE ${myuniversity}_${mymodule}.mapping_profiles
+SET jsonb = jsonb_set(jsonb, '{mappingDetails, mappingFields}', (jsonb -> 'mappingDetails' -> 'mappingFields') - 44)
+WHERE id IN (SELECT id FROM profiles_ids);

--- a/mod-di-converter-storage-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-di-converter-storage-server/src/main/resources/templates/db_scripts/schema.json
@@ -479,6 +479,11 @@
       "run": "after",
       "snippetPath": "data-migration/set_required_true_for_order_vendor_and_contributor.sql",
       "fromModuleVersion": "mod-di-converter-storage-2.4.0"
+    },
+    {
+      "run": "after",
+      "snippetPath": "data-migration/fix_order_mapping_profiles.sql",
+      "fromModuleVersion": "mod-di-converter-storage-2.3.2"
     }
   ]
 }

--- a/mod-di-converter-storage-server/src/test/java/org/folio/rest/impl/JobProfileTest.java
+++ b/mod-di-converter-storage-server/src/test/java/org/folio/rest/impl/JobProfileTest.java
@@ -433,7 +433,7 @@ public class JobProfileTest extends AbstractRestVerticleTest {
       .post(JOB_PROFILES_PATH)
       .then().log().all()
       .statusCode(HttpStatus.SC_UNPROCESSABLE_ENTITY)
-      .body("errors[0].message", is("Job profile 'tree2' already exists"));
+      .body("errors[0].message", is("Job profile 'Bla' already exists"));
   }
 
   @Test


### PR DESCRIPTION
## Purpose
to fix order mapping profiles

## Approach
* add migration scirpt to remove redundant mapping for "donorOrganizationIds" field that might have been added
  due to the repeated execution of the add_donor_organizations_ids_mapping.sql migration script


## Learning
[MODDICONV-418](https://issues.folio.org/browse/MODDICONV-418)