### PR TITLE
MODDICONV-436 - Set Authority DELETE job/action/field mapping profiles to display via Settings > Data import

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 2026-mm-dd 2.6.0-SNAPSHOT
+* [MODDICONV-436](https://issues.folio.org/browse/MODDICONV-436) Set Authority DELETE job/action/field mapping profiles to display via Settings > Data import
+
 ## 2025-04-14 2.5.0
 * [MODDICONV-425](https://folio-org.atlassian.net/browse/MODDICONV-425) Create new Default Mapping profile for Mosaic invoices
 * [MODDICONV-429](https://folio-org.atlassian.net/browse/MODDICONV-429) Upgrade module to Vert.x 5.0

--- a/mod-di-converter-storage-server/src/main/java/org/folio/rest/impl/ModTenantAPI.java
+++ b/mod-di-converter-storage-server/src/main/java/org/folio/rest/impl/ModTenantAPI.java
@@ -50,6 +50,7 @@ public class ModTenantAPI extends TenantAPI {
   private static final String DEFAULT_QM_AUTHORITY_CREATE_JOB_PROFILE = "templates/db_scripts/defaultData/default_qm_authority_create_job_profile.sql";
   private static final String DEFAULT_ECS_INSTANCE_AND_MARC_BIB_CREATE_JOB_PROFILE = "templates/db_scripts/defaultData/default_ecs_instance_and_marc_bib_create_job_profile.sql";
   private static final String DEFAULT_MOSAIC_EDIFACT_MAPPING_PROFILE = "templates/db_scripts/defaultData/default_mosaic_edifact_mapping_profile.sql";
+  private static final String UPDATE_DEFAULT_DELETE_MARC_AUTHORITY_JOB_PROFILE = "templates/db_scripts/defaultData/update_default_delete_marc_authority_job_profile.sql";
   private static final String RENAME_MODULE = "templates/db_scripts/rename_module.sql";
 
   private static final String TENANT_PLACEHOLDER = "${myuniversity}";
@@ -98,6 +99,7 @@ public class ModTenantAPI extends TenantAPI {
         .compose(m -> runSqlScript(DEFAULT_ECS_INSTANCE_AND_MARC_BIB_CREATE_JOB_PROFILE, headers, context))
         .compose(m -> runSqlScript(DEFAULT_QM_AUTHORITY_CREATE_JOB_PROFILE, headers, context))
         .compose(m -> runSqlScript(DEFAULT_MOSAIC_EDIFACT_MAPPING_PROFILE, headers, context))
+        .compose(m -> runSqlScript(UPDATE_DEFAULT_DELETE_MARC_AUTHORITY_JOB_PROFILE, headers, context))
         .map(num));
   }
 

--- a/mod-di-converter-storage-server/src/main/java/org/folio/rest/impl/ModTenantAPI.java
+++ b/mod-di-converter-storage-server/src/main/java/org/folio/rest/impl/ModTenantAPI.java
@@ -50,7 +50,6 @@ public class ModTenantAPI extends TenantAPI {
   private static final String DEFAULT_QM_AUTHORITY_CREATE_JOB_PROFILE = "templates/db_scripts/defaultData/default_qm_authority_create_job_profile.sql";
   private static final String DEFAULT_ECS_INSTANCE_AND_MARC_BIB_CREATE_JOB_PROFILE = "templates/db_scripts/defaultData/default_ecs_instance_and_marc_bib_create_job_profile.sql";
   private static final String DEFAULT_MOSAIC_EDIFACT_MAPPING_PROFILE = "templates/db_scripts/defaultData/default_mosaic_edifact_mapping_profile.sql";
-  private static final String UPDATE_DEFAULT_DELETE_MARC_AUTHORITY_JOB_PROFILE = "templates/db_scripts/defaultData/update_default_delete_marc_authority_job_profile.sql";
   private static final String RENAME_MODULE = "templates/db_scripts/rename_module.sql";
 
   private static final String TENANT_PLACEHOLDER = "${myuniversity}";
@@ -99,7 +98,6 @@ public class ModTenantAPI extends TenantAPI {
         .compose(m -> runSqlScript(DEFAULT_ECS_INSTANCE_AND_MARC_BIB_CREATE_JOB_PROFILE, headers, context))
         .compose(m -> runSqlScript(DEFAULT_QM_AUTHORITY_CREATE_JOB_PROFILE, headers, context))
         .compose(m -> runSqlScript(DEFAULT_MOSAIC_EDIFACT_MAPPING_PROFILE, headers, context))
-        .compose(m -> runSqlScript(UPDATE_DEFAULT_DELETE_MARC_AUTHORITY_JOB_PROFILE, headers, context))
         .map(num));
   }
 

--- a/mod-di-converter-storage-server/src/main/java/org/folio/services/AbstractProfileService.java
+++ b/mod-di-converter-storage-server/src/main/java/org/folio/services/AbstractProfileService.java
@@ -84,7 +84,7 @@ public abstract class AbstractProfileService<T, S, D> implements ProfileService<
   protected AbstractProfileService() {
     List<String> entityTypeList = Arrays.stream(EntityTypes.values())
       .map(EntityTypes::getName)
-      .collect(Collectors.toList());
+      .toList();
     entityTypeCollection = new EntityTypeCollection()
       .withEntityTypes(entityTypeList)
       .withTotalRecords(entityTypeList.size());
@@ -141,7 +141,7 @@ public abstract class AbstractProfileService<T, S, D> implements ProfileService<
 
     List<Future<Boolean>> futureList = profileAssociations.stream()
       .map(association -> deleteAssociation(association, tenantId))
-      .collect(Collectors.toList());
+      .toList();
 
     Promise<Boolean> result = Promise.promise();
     Future.all(futureList).onComplete(ar -> {
@@ -277,7 +277,7 @@ public abstract class AbstractProfileService<T, S, D> implements ProfileService<
     }
 
     return profileDao.isProfileAssociatedAsDetail(id, tenantId)
-      .compose(isAssociated -> isAssociated
+      .compose(isAssociated -> Boolean.TRUE.equals(isAssociated)
         ? Future.failedFuture(new ConflictException(String.format(DELETE_PROFILE_ERROR_MESSAGE, id)))
         : profileDao.hardDeleteProfile(id, tenantId))
       .map(true);
@@ -543,7 +543,7 @@ public abstract class AbstractProfileService<T, S, D> implements ProfileService<
           .filter(errorCode -> ar.result().resultAt(errorCodes.indexOf(errorCode)))
           .map(errorCode -> new Error().withMessage(format(errorCode,
             ERROR_CODES_TYPES_RELATION.get(profileTypeName), getProfileName(profile))))
-          .collect(Collectors.toList());
+          .collect(Collectors.toCollection(ArrayList::new));
         promise.complete(new Errors().withErrors(errors).withTotalRecords(errors.size()));
       } else {
         promise.fail(ar.cause());

--- a/mod-di-converter-storage-server/src/main/java/org/folio/services/MatchProfileServiceImpl.java
+++ b/mod-di-converter-storage-server/src/main/java/org/folio/services/MatchProfileServiceImpl.java
@@ -17,10 +17,10 @@ import java.util.UUID;
 
 @Component
 public class MatchProfileServiceImpl extends AbstractProfileService<MatchProfile, MatchProfileCollection, MatchProfileUpdateDto> {
+  private static final String DEFAULT_DELETE_MARC_AUTHORITY_MATCH_PROFILE_ID = "4be5d1d2-1f5a-42ff-a9bd-fc90609d94b6";
   private static final List<String> DEFAULT_MATCH_PROFILES = Arrays.asList(
     "d27d71ce-8a1e-44c6-acea-96961b5592c6", //OCLC_MARC_MARC_MATCH_PROFILE_ID
     "31dbb554-0826-48ec-a0a4-3c55293d4dee", //OCLC_INSTANCE_UUID_MATCH_PROFILE_ID
-    "4be5d1d2-1f5a-42ff-a9bd-fc90609d94b6",  //DEFAULT_DELETE_MARC_AUTHORITY_MATCH_PROFILE_ID
     "91cec42a-260d-4a8c-a9fb-90d9435ca2f4", //DEFAULT_QM_MARC_BIB_UPDATE_MATCH_PROFILE_ID
     "2a599369-817f-4fe8-bae2-f3e3987990fe", //DEFAULT_QM_HOLDINGS_UPDATE_MATCH_PROFILE_ID
     "aff72eae-847c-4a97-b7b9-c1ddb8cdcbbf"  //DEFAULT_QM_AUTHORITY_UPDATE_MATCH_PROFILE_ID
@@ -121,5 +121,10 @@ public class MatchProfileServiceImpl extends AbstractProfileService<MatchProfile
   @Override
   protected List<String> getDefaultProfiles() {
     return DEFAULT_MATCH_PROFILES;
+  }
+
+  @Override
+  protected boolean canDeleteProfile(String profileId) {
+    return !DEFAULT_DELETE_MARC_AUTHORITY_MATCH_PROFILE_ID.equals(profileId) && super.canDeleteProfile(profileId);
   }
 }

--- a/mod-di-converter-storage-server/src/main/java/org/folio/services/MatchProfileServiceImpl.java
+++ b/mod-di-converter-storage-server/src/main/java/org/folio/services/MatchProfileServiceImpl.java
@@ -17,6 +17,7 @@ import java.util.UUID;
 
 @Component
 public class MatchProfileServiceImpl extends AbstractProfileService<MatchProfile, MatchProfileCollection, MatchProfileUpdateDto> {
+  @SuppressWarnings("java:S6418") // Suppress warning about 'AUTH' detection meaning potentially hard-coded secret
   private static final String DEFAULT_DELETE_MARC_AUTHORITY_MATCH_PROFILE_ID = "4be5d1d2-1f5a-42ff-a9bd-fc90609d94b6";
   private static final List<String> DEFAULT_MATCH_PROFILES = Arrays.asList(
     "d27d71ce-8a1e-44c6-acea-96961b5592c6", //OCLC_MARC_MARC_MATCH_PROFILE_ID

--- a/mod-di-converter-storage-server/src/main/java/org/folio/services/MatchProfileServiceImpl.java
+++ b/mod-di-converter-storage-server/src/main/java/org/folio/services/MatchProfileServiceImpl.java
@@ -9,13 +9,13 @@ import org.folio.rest.jaxrs.model.MatchProfileUpdateDto;
 import org.folio.rest.jaxrs.model.ProfileAssociation;
 import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
 import org.folio.rest.jaxrs.model.ProfileType;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 
-@Component
+@Service
 public class MatchProfileServiceImpl extends AbstractProfileService<MatchProfile, MatchProfileCollection, MatchProfileUpdateDto> {
   @SuppressWarnings("java:S6418") // Suppress warning about 'AUTH' detection meaning potentially hard-coded secret
   private static final String DEFAULT_DELETE_MARC_AUTHORITY_MATCH_PROFILE_ID = "4be5d1d2-1f5a-42ff-a9bd-fc90609d94b6";
@@ -25,13 +25,13 @@ public class MatchProfileServiceImpl extends AbstractProfileService<MatchProfile
     "91cec42a-260d-4a8c-a9fb-90d9435ca2f4", //DEFAULT_QM_MARC_BIB_UPDATE_MATCH_PROFILE_ID
     "2a599369-817f-4fe8-bae2-f3e3987990fe", //DEFAULT_QM_HOLDINGS_UPDATE_MATCH_PROFILE_ID
     "aff72eae-847c-4a97-b7b9-c1ddb8cdcbbf"  //DEFAULT_QM_AUTHORITY_UPDATE_MATCH_PROFILE_ID
-    );
+  );
 
   @Override
   MatchProfile setProfileId(MatchProfile profile) {
     String profileId = profile.getId();
-    return profile.withId(StringUtils.isBlank(profileId) ?
-      UUID.randomUUID().toString() : profileId);
+    return profile.withId(StringUtils.isBlank(profileId)
+      ? UUID.randomUUID().toString() : profileId);
   }
 
   @Override

--- a/mod-di-converter-storage-server/src/main/resources/templates/db_scripts/defaultData/default_delete_marc_authority_job_profile.sql
+++ b/mod-di-converter-storage-server/src/main/resources/templates/db_scripts/defaultData/default_delete_marc_authority_job_profile.sql
@@ -1,10 +1,10 @@
 INSERT INTO ${myuniversity}_${mymodule}.job_profiles (id, jsonb) values
 ('1a338fcd-3efc-4a03-b007-394eeb0d5fb9', '{
   "id": "1a338fcd-3efc-4a03-b007-394eeb0d5fb9",
-  "name": "Default - Delete MARC Authority",
-  "description": "This job profile is used for deleting an MARC authority record via the MARC authority app. This profile deletes the authority record stored in source-record-storage and mod-inventory-storage. This job profile cannot be edited, duplicated, or deleted.",
+  "name": "Default - Delete MARC Authority records",
+  "description": "Default job profile to delete MARC authority records. This job profile cannot be edited or deleted.",
   "dataType": "MARC",
-  "hidden": true,
+  "hidden": false,
   "userInfo": {
     "firstName": "System",
     "lastName": "System",
@@ -23,11 +23,11 @@ INSERT INTO ${myuniversity}_${mymodule}.job_profiles (id, jsonb) values
 INSERT INTO ${myuniversity}_${mymodule}.action_profiles (id, jsonb) values
   ('fabd9a3e-33c3-49b7-864d-c5af830d9990', '{
   "id": "fabd9a3e-33c3-49b7-864d-c5af830d9990",
-  "name": "Default - Delete MARC Authority via MARC Authority app",
-  "description": "This action profile is used with FOLIO''s default job profile for deleting an MARC authority record via the MARC authority app. This profile deletes the authority record stored in source-record-storage and mod-inventory-storage. This action profile cannot be edited, duplicated, or deleted.",
+  "name": "Default - Delete MARC Authority records",
+  "description": "This action profile is used to delete MARC authority records. This action profile cannot be duplicated, edited, or deleted.",
   "action": "DELETE",
   "folioRecord": "MARC_AUTHORITY",
-  "hidden": true,
+  "hidden": false,
   "remove9Subfields": false,
   "userInfo": {
     "firstName": "System",
@@ -49,8 +49,8 @@ INSERT INTO ${myuniversity}_${mymodule}.match_profiles (id, jsonb) values
 ('4be5d1d2-1f5a-42ff-a9bd-fc90609d94b6',
 '{
   "id": "4be5d1d2-1f5a-42ff-a9bd-fc90609d94b6",
-  "name": "Default - Delete MARC Authority",
-  "description": "This match profile is used with FOLIO''s default job profile for deleting an MARC authority record via the MARC authority app. This profile deletes the authority record stored in source-record-storage and mod-inventory-storage. This match profile cannot be edited, duplicated, or deleted.",
+  "name": "Default - Delete MARC Authority records",
+  "description": "This match profile is used to delete MARC authority records. The default field is set to 999 ff $s. This match profile cannot be deleted, but it can edited or duplicated.",
   "incomingRecordType": "MARC_AUTHORITY",
   "existingRecordType": "MARC_AUTHORITY",
   "matchDetails": [
@@ -102,7 +102,7 @@ INSERT INTO ${myuniversity}_${mymodule}.match_profiles (id, jsonb) values
       }
     }
   ],
-  "hidden": true,
+  "hidden": false,
   "userInfo": {
     "firstName": "System",
     "lastName": "System",

--- a/mod-di-converter-storage-server/src/main/resources/templates/db_scripts/defaultData/update_default_delete_marc_authority_job_profile.sql
+++ b/mod-di-converter-storage-server/src/main/resources/templates/db_scripts/defaultData/update_default_delete_marc_authority_job_profile.sql
@@ -1,0 +1,29 @@
+UPDATE ${myuniversity}_${mymodule}.job_profiles
+SET jsonb = jsonb_set(
+  jsonb_set(
+    jsonb_set(jsonb, '{hidden}', 'false'::jsonb),
+    '{name}', 'Default - Delete MARC Authority records'::jsonb
+  ),
+  '{description}', 'Default job profile to delete MARC authority records. This job profile cannot be edited or deleted.'::jsonb
+)
+WHERE id = '1a338fcd-3efc-4a03-b007-394eeb0d5fb9';
+
+UPDATE ${myuniversity}_${mymodule}.action_profiles
+SET jsonb = jsonb_set(
+  jsonb_set(
+    jsonb_set(jsonb, '{hidden}', 'false'::jsonb),
+    '{name}', 'Default - Delete MARC Authority records'::jsonb
+  ),
+  '{description}', 'This action profile is used to delete MARC authority records. This action profile cannot be duplicated, edited, or deleted.'::jsonb
+)
+WHERE id = 'fabd9a3e-33c3-49b7-864d-c5af830d9990';
+
+UPDATE ${myuniversity}_${mymodule}.match_profiles
+SET jsonb = jsonb_set(
+  jsonb_set(
+    jsonb_set(jsonb, '{hidden}', 'false'::jsonb),
+    '{name}', 'Default - Delete MARC Authority records'::jsonb
+  ),
+  '{description}', 'This match profile is used to delete MARC authority records. The default field is set to 999 ff $s. This match profile cannot be deleted, but it can edited or duplicated.'::jsonb
+)
+WHERE id = '4be5d1d2-1f5a-42ff-a9bd-fc90609d94b6';

--- a/mod-di-converter-storage-server/src/main/resources/templates/db_scripts/defaultData/update_default_delete_marc_authority_job_profile.sql
+++ b/mod-di-converter-storage-server/src/main/resources/templates/db_scripts/defaultData/update_default_delete_marc_authority_job_profile.sql
@@ -2,9 +2,9 @@ UPDATE ${myuniversity}_${mymodule}.job_profiles
 SET jsonb = jsonb_set(
   jsonb_set(
     jsonb_set(jsonb, '{hidden}', 'false'::jsonb),
-    '{name}', 'Default - Delete MARC Authority records'::jsonb
+    '{name}', '"Default - Delete MARC Authority records"'::jsonb
   ),
-  '{description}', 'Default job profile to delete MARC authority records. This job profile cannot be edited or deleted.'::jsonb
+  '{description}', '"Default job profile to delete MARC authority records. This job profile cannot be edited or deleted."'::jsonb
 )
 WHERE id = '1a338fcd-3efc-4a03-b007-394eeb0d5fb9';
 
@@ -12,9 +12,9 @@ UPDATE ${myuniversity}_${mymodule}.action_profiles
 SET jsonb = jsonb_set(
   jsonb_set(
     jsonb_set(jsonb, '{hidden}', 'false'::jsonb),
-    '{name}', 'Default - Delete MARC Authority records'::jsonb
+    '{name}', '"Default - Delete MARC Authority records"'::jsonb
   ),
-  '{description}', 'This action profile is used to delete MARC authority records. This action profile cannot be duplicated, edited, or deleted.'::jsonb
+  '{description}', '"This action profile is used to delete MARC authority records. This action profile cannot be duplicated, edited, or deleted."'::jsonb
 )
 WHERE id = 'fabd9a3e-33c3-49b7-864d-c5af830d9990';
 
@@ -22,8 +22,16 @@ UPDATE ${myuniversity}_${mymodule}.match_profiles
 SET jsonb = jsonb_set(
   jsonb_set(
     jsonb_set(jsonb, '{hidden}', 'false'::jsonb),
-    '{name}', 'Default - Delete MARC Authority records'::jsonb
+    '{name}', '"Default - Delete MARC Authority records"'::jsonb
   ),
-  '{description}', 'This match profile is used to delete MARC authority records. The default field is set to 999 ff $s. This match profile cannot be deleted, but it can edited or duplicated.'::jsonb
+  '{description}', '"This match profile is used to delete MARC authority records. The default field is set to 999 ff $s. This match profile cannot be deleted, but it can edited or duplicated."'::jsonb
 )
 WHERE id = '4be5d1d2-1f5a-42ff-a9bd-fc90609d94b6';
+
+
+-- Corrects detail_wrapper_id in the job-to-match association for default delete MARC authority job profile
+-- defined in the default_delete_marc_authority_job_profile.sql
+-- to have job-to-match relationship instead of job-to-action relationship.
+UPDATE ${myuniversity}_${mymodule}.profile_associations
+SET detail_wrapper_id = '69de98ea-68dd-46be-a187-a115f9afcc05'
+WHERE id = '644e53c2-7be2-4ae5-bc17-131334222d39';

--- a/mod-di-converter-storage-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-di-converter-storage-server/src/main/resources/templates/db_scripts/schema.json
@@ -204,6 +204,11 @@
       "run": "after",
       "snippetPath": "associations-migration/remove_old_association_tables.sql",
       "fromModuleVersion": "mod-di-converter-storage-2.5.0"
+    },
+    {
+      "run": "after",
+      "snippetPath": "defaultData/update_default_delete_marc_authority_job_profile.sql",
+      "fromModuleVersion": "mod-di-converter-storage-2.6.0"
     }
   ]
 }

--- a/mod-di-converter-storage-server/src/test/java/org/folio/rest/impl/DefaultJobProfileTest.java
+++ b/mod-di-converter-storage-server/src/test/java/org/folio/rest/impl/DefaultJobProfileTest.java
@@ -41,7 +41,7 @@ public class DefaultJobProfileTest extends AbstractRestVerticleTest {
       .get(JOB_PROFILES_PATH)
       .then()
       .statusCode(HttpStatus.SC_OK)
-      .body("totalRecords", is(7));
+      .body("totalRecords", is(8));
   }
 
   @Test

--- a/mod-di-converter-storage-server/src/test/java/org/folio/rest/impl/DefaultMatchProfileTest.java
+++ b/mod-di-converter-storage-server/src/test/java/org/folio/rest/impl/DefaultMatchProfileTest.java
@@ -20,11 +20,12 @@ import static org.hamcrest.core.Is.is;
 public class DefaultMatchProfileTest extends AbstractRestVerticleTest{
 
   private static final String OCLC_INSTANCE_UUID_MATCH_PROFILE_ID = "31dbb554-0826-48ec-a0a4-3c55293d4dee";
+  private static final String DEFAULT_DELETE_MARC_AUTHORITY_MATCH_PROFILE_ID = "4be5d1d2-1f5a-42ff-a9bd-fc90609d94b6";
 
   @Test
   public void shouldAddAndRemoveTagsDefaultProfile() {
     Tags tags = new Tags().withTagList(Arrays.asList("Lorem", "ipsum"));
-    var profile = getMappingProfileById(OCLC_INSTANCE_UUID_MATCH_PROFILE_ID);
+    var profile = getMatchProfileById(OCLC_INSTANCE_UUID_MATCH_PROFILE_ID);
 //    Add tags to default profile
     RestAssured.given()
       .spec(spec)
@@ -35,7 +36,7 @@ public class DefaultMatchProfileTest extends AbstractRestVerticleTest{
       .statusCode(HttpStatus.SC_OK)
       .body("tags.tagList", is(tags.getTagList()));
 
-    profile = getMappingProfileById(OCLC_INSTANCE_UUID_MATCH_PROFILE_ID);
+    profile = getMatchProfileById(OCLC_INSTANCE_UUID_MATCH_PROFILE_ID);
 //    Delete tags from default profile
     RestAssured.given()
       .spec(spec)
@@ -47,7 +48,22 @@ public class DefaultMatchProfileTest extends AbstractRestVerticleTest{
       .body("tags.tagList", is(Matchers.empty()));
   }
 
-  private MatchProfile getMappingProfileById(String id) {
+  @Test
+  public void shouldUpdateDefaultDeleteMarcAuthorityMatchProfileOnPut() {
+    var profile = getMatchProfileById(DEFAULT_DELETE_MARC_AUTHORITY_MATCH_PROFILE_ID);
+    profile.setName("Changed name");
+    RestAssured.given()
+      .spec(spec)
+      .body(new MatchProfileUpdateDto().withProfile(profile))
+      .when()
+      .put(MATCH_PROFILES_PATH + "/" + DEFAULT_DELETE_MARC_AUTHORITY_MATCH_PROFILE_ID)
+      .then()
+      .statusCode(HttpStatus.SC_OK)
+      .log().all()
+      .body("name", is(profile.getName()));
+  }
+
+  private MatchProfile getMatchProfileById(String id) {
     return RestAssured.given()
       .spec(spec)
       .when()

--- a/mod-di-converter-storage-server/src/test/java/org/folio/rest/impl/DefaultMatchProfileTest.java
+++ b/mod-di-converter-storage-server/src/test/java/org/folio/rest/impl/DefaultMatchProfileTest.java
@@ -52,6 +52,7 @@ public class DefaultMatchProfileTest extends AbstractRestVerticleTest{
   public void shouldUpdateDefaultDeleteMarcAuthorityMatchProfileOnPut() {
     var profile = getMatchProfileById(DEFAULT_DELETE_MARC_AUTHORITY_MATCH_PROFILE_ID);
     profile.setName("Changed name");
+
     RestAssured.given()
       .spec(spec)
       .body(new MatchProfileUpdateDto().withProfile(profile))

--- a/mod-di-converter-storage-server/src/test/java/org/folio/rest/impl/MatchProfileTest.java
+++ b/mod-di-converter-storage-server/src/test/java/org/folio/rest/impl/MatchProfileTest.java
@@ -740,9 +740,15 @@ MatchDetail receivedMatchDetail1 = receivedMatchProfile.getMatchDetails().get(0)
 
   private void createProfilesTree(List<String> profilesIds) {
     String nameForProfiles = "tree";
-    List<JobProfileUpdateDto> jobProfiles = Arrays.asList(jobProfile_1, jobProfile_1, jobProfile_1);
-    List<ActionProfileUpdateDto> actionProfiles = Arrays.asList(actionProfile_1, actionProfile_1, actionProfile_1);
-    List<MappingProfileUpdateDto> mappingProfiles = Arrays.asList(mappingProfile_1, mappingProfile_2, mappingProfile_3);
+    JobProfileUpdateDto clonedJobProfile1 = JsonObject.mapFrom(jobProfile_1).mapTo(JobProfileUpdateDto.class);
+    ActionProfileUpdateDto clonedActionProfile1 = JsonObject.mapFrom(actionProfile_1).mapTo(ActionProfileUpdateDto.class);
+    MappingProfileUpdateDto clonedMappingProfile1 = JsonObject.mapFrom(mappingProfile_1).mapTo(MappingProfileUpdateDto.class);
+    MappingProfileUpdateDto clonedMappingProfile2 = JsonObject.mapFrom(mappingProfile_2).mapTo(MappingProfileUpdateDto.class);
+    MappingProfileUpdateDto clonedMappingProfile3 = JsonObject.mapFrom(mappingProfile_3).mapTo(MappingProfileUpdateDto.class);
+
+    List<JobProfileUpdateDto> jobProfiles = Arrays.asList(clonedJobProfile1, clonedJobProfile1, clonedJobProfile1);
+    List<ActionProfileUpdateDto> actionProfiles = Arrays.asList(clonedActionProfile1, clonedActionProfile1, clonedActionProfile1);
+    List<MappingProfileUpdateDto> mappingProfiles = Arrays.asList(clonedMappingProfile1, clonedMappingProfile2, clonedMappingProfile3);
     List<JobProfileUpdateDto> created = new ArrayList<>();
     List<MappingProfileUpdateDto> createdMappings = new ArrayList<>();
     List<ActionProfileUpdateDto> createdActions = new ArrayList<>();

--- a/mod-di-converter-storage-server/src/test/java/org/folio/rest/impl/MatchProfileTest.java
+++ b/mod-di-converter-storage-server/src/test/java/org/folio/rest/impl/MatchProfileTest.java
@@ -74,7 +74,12 @@ public class MatchProfileTest extends AbstractRestVerticleTest {
 
   private static final String PROFILE_WRAPPERS_TABLE = "profile_wrappers";
 
-  private List<String> defaultMatchedProfileIds = Arrays.asList(
+  private static final List<String> DEFAULT_MATCH_PROFILE_IDS_RESTRICTED_FOR_UPDATE = Arrays.asList(
+    "d27d71ce-8a1e-44c6-acea-96961b5592c6", //OCLC_MARC_MARC_MATCH_PROFILE_ID
+    "31dbb554-0826-48ec-a0a4-3c55293d4dee"  //OCLC_INSTANCE_UUID_MATCH_PROFILE_ID
+  );
+
+  private static final List<String> DEFAULT_MATCH_PROFILE_IDS_RESTRICTED_FOR_DELETION = List.of(
     "d27d71ce-8a1e-44c6-acea-96961b5592c6", //OCLC_MARC_MARC_MATCH_PROFILE_ID
     "31dbb554-0826-48ec-a0a4-3c55293d4dee", //OCLC_INSTANCE_UUID_MATCH_PROFILE_ID
     "4be5d1d2-1f5a-42ff-a9bd-fc90609d94b6"  //DEFAULT_DELETE_MARC_AUTHORITY_MATCH_PROFILE_ID
@@ -224,7 +229,7 @@ public class MatchProfileTest extends AbstractRestVerticleTest {
   @Test
   public void shouldReturnBadRequestOnPutWithDefaultProfiles() {
     createProfiles();
-    for (String id : defaultMatchedProfileIds) {
+    for (String id : DEFAULT_MATCH_PROFILE_IDS_RESTRICTED_FOR_UPDATE) {
       RestAssured.given()
         .spec(spec)
         .body(matchProfile_1)
@@ -238,7 +243,7 @@ public class MatchProfileTest extends AbstractRestVerticleTest {
   @Test
   public void shouldReturnBadRequestOnDeleteWithDefaultProfiles() {
     createProfiles();
-    for (String id : defaultMatchedProfileIds) {
+    for (String id : DEFAULT_MATCH_PROFILE_IDS_RESTRICTED_FOR_DELETION) {
       RestAssured.given()
         .spec(spec)
         .when()

--- a/mod-di-converter-storage-server/src/test/java/org/folio/rest/impl/MatchProfileTest.java
+++ b/mod-di-converter-storage-server/src/test/java/org/folio/rest/impl/MatchProfileTest.java
@@ -74,7 +74,7 @@ public class MatchProfileTest extends AbstractRestVerticleTest {
 
   private static final String PROFILE_WRAPPERS_TABLE = "profile_wrappers";
 
-  private static final List<String> DEFAULT_MATCH_PROFILE_IDS_RESTRICTED_FOR_UPDATE = Arrays.asList(
+  private static final List<String> DEFAULT_MATCH_PROFILE_IDS_RESTRICTED_FOR_UPDATE = List.of(
     "d27d71ce-8a1e-44c6-acea-96961b5592c6", //OCLC_MARC_MARC_MATCH_PROFILE_ID
     "31dbb554-0826-48ec-a0a4-3c55293d4dee"  //OCLC_INSTANCE_UUID_MATCH_PROFILE_ID
   );


### PR DESCRIPTION
## Purpose
To make default delete MARC-AUTHORITY job, action, match profiles visible in the UI and to update their name and description.
The job and action profiles should not be allowed to be updated or deleted.
The match profile should be restricted from deletion but allowed to be updated, so that users can change the MARC field for matching in the matching criteria if needed.

## Approach
* prepared script to make the default delete MARC-AUTHORITY job, action, match profiles visible in the UI,
and to update their name and description. 
The script call is performed from the schema.json file,instead of the ModTenantAPI class, in order to run the script only once during a module upgrade and to avoid overwriting of changes users may have made to the name or description of the default "Delete MARC-AUTHORITY" match profile during subsequent module upgrades, as the match profile the profile becomes allowed for update by users.
* updated the initial script for creating default delete MARC-AUTHORITY profiles to make the profiles visible and to ensure expected name/description values when the module is deployed from scratch. This is necessary because the newly added script for updating these profiles is executed earlier than the initial script for their creation.
* changed the logic to allow the default delete MARC-AUTHORITY match profile to be updated
* fixed job-to-match association for the default delete MARC authority job profile to have job-to-match relationship instead of direct job-to-action relationship
* updated tests


## Learning
[MODDICONV-436](https://issues.folio.org/browse/MODDICONV-436)

